### PR TITLE
gitops: add stakater reloader

### DIFF
--- a/future-sir-gitops/base/reloader/deployments.yaml
+++ b/future-sir-gitops/base/reloader/deployments.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reloader
+  labels:
+    app.kubernetes.io/name: reloader
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: reloader
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: reloader
+    spec:
+      containers:
+        - image: ghcr.io/stakater/reloader:v1.2.0
+          env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef: { fieldPath: metadata.namespace }
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: '1'
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: '1'
+                  resource: limits.memory
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /live
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: reloader
+          ports:
+            - containerPort: 9090
+              name: http
+          readinessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /metrics
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: '1'
+              memory: 512Mi
+            requests:
+              cpu: 10m
+              memory: 512Mi
+          securityContext: {}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: reloader

--- a/future-sir-gitops/base/reloader/kustomization.yaml
+++ b/future-sir-gitops/base/reloader/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: future-social-insurance-registry
+resources:
+  - ./roles.yaml
+  - ./service-accounts.yaml
+  - ./deployments.yaml

--- a/future-sir-gitops/base/reloader/roles.yaml
+++ b/future-sir-gitops/base/reloader/roles.yaml
@@ -1,0 +1,71 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: reloader-role
+  labels:
+    app.kubernetes.io/name: reloader-role
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+      - configmaps
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - statefulsets
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - extensions
+    resources:
+      - deployments
+      - daemonsets
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+    verbs:
+      - list
+      - get
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: reloader-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: reloader-role
+subjects:
+  - kind: ServiceAccount
+    name: reloader

--- a/future-sir-gitops/base/reloader/service-accounts.yaml
+++ b/future-sir-gitops/base/reloader/service-accounts.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: reloader
+  labels:
+    app.kubernetes.io/name: reloader

--- a/future-sir-gitops/overlays/dev/patches/deployments.yaml
+++ b/future-sir-gitops/overlays/dev/patches/deployments.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: future-sir-frontend
+  annotations:
+    secret.reloader.stakater.com/auto: 'true'
 spec:
   selector:
     matchLabels:

--- a/future-sir-gitops/overlays/shared/kustomization.yaml
+++ b/future-sir-gitops/overlays/shared/kustomization.yaml
@@ -19,6 +19,7 @@ labels:
       app.kubernetes.io/tier: nonprod
 resources:
   - ../../base/redis/
+  - ../../base/reloader/
   - ./external-secrets.yaml
 patches:
   - path: ./patches/stateful-sets.yaml

--- a/future-sir-gitops/overlays/shared/patches/stateful-sets.yaml
+++ b/future-sir-gitops/overlays/shared/patches/stateful-sets.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: redis
+  annotations:
+    secret.reloader.stakater.com/auto: 'true'
 spec:
   serviceName: redis-headless
   selector:


### PR DESCRIPTION
Add Stakater Reloader to monitor ESO secrets and restart the pods whenever the secrets change.

- <https://docs.stakater.com/reloader/>