### PR TITLE
refactor: remove `constructor.name` from auth strategy base class

### DIFF
--- a/future-sir-frontend/app/routes/auth/callback.tsx
+++ b/future-sir-frontend/app/routes/auth/callback.tsx
@@ -73,7 +73,7 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
 async function handleCallback(authStrategy: AuthenticationStrategy, currentUrl: URL, session: AppLoadContext['session']) {
   return withSpan('routes.auth.callback.handle_callback', async (span) => {
     span.setAttribute('request_url', currentUrl.toString());
-    span.setAttribute('strategy', authStrategy.constructor.name);
+    span.setAttribute('strategy', authStrategy.name);
 
     if (session.loginState === undefined) {
       span.addEvent('login_state.invalid');

--- a/future-sir-frontend/app/routes/auth/login.tsx
+++ b/future-sir-frontend/app/routes/auth/login.tsx
@@ -85,7 +85,7 @@ async function handleLogin(authStrategy: AuthenticationStrategy, currentUrl: URL
 
   span?.setAttribute('request_url', currentUrl.toString());
   span?.setAttribute('returnto', returnTo ?? 'not_provided');
-  span?.setAttribute('strategy', authStrategy.constructor.name);
+  span?.setAttribute('strategy', authStrategy.name);
 
   span?.addEvent('signin_request.start');
   const signinRequest = await authStrategy.generateSigninRequest(['openid', 'profile', 'email']);

--- a/future-sir-frontend/app/utils/auth/azuread-authentication-strategy.ts
+++ b/future-sir-frontend/app/utils/auth/azuread-authentication-strategy.ts
@@ -7,6 +7,6 @@ import { BaseAuthenticationStrategy } from '~/utils/auth/authentication-strategy
  */
 export class AzureADAuthenticationStrategy extends BaseAuthenticationStrategy {
   public constructor(issuerUrl: URL, callbackUrl: URL, clientId: string, clientSecret: string) {
-    super(issuerUrl, callbackUrl, { client_id: clientId }, ClientSecretPost(clientSecret));
+    super('azuread', issuerUrl, callbackUrl, { client_id: clientId }, ClientSecretPost(clientSecret));
   }
 }

--- a/future-sir-frontend/app/utils/auth/local-authentication-strategy.ts
+++ b/future-sir-frontend/app/utils/auth/local-authentication-strategy.ts
@@ -8,6 +8,6 @@ import { BaseAuthenticationStrategy } from '~/utils/auth/authentication-strategy
  */
 export class LocalAuthenticationStrategy extends BaseAuthenticationStrategy {
   public constructor(issuerUrl: URL, callbackUrl: URL, clientId: string, clientSecret: string) {
-    super(issuerUrl, callbackUrl, { client_id: clientId }, ClientSecretPost(clientSecret), true);
+    super('local', issuerUrl, callbackUrl, { client_id: clientId }, ClientSecretPost(clientSecret), true);
   }
 }

--- a/future-sir-frontend/tests/utils/auth/authentication-strategy.test.ts
+++ b/future-sir-frontend/tests/utils/auth/authentication-strategy.test.ts
@@ -9,6 +9,7 @@ describe('BaseAuthenticationStrategy', () => {
   class TestAuthStrategy extends BaseAuthenticationStrategy {
     constructor() {
       super(
+        'test',
         new URL('https://auth.example.com/issuer'),
         new URL('https://auth.example.com/callback'),
         { client_id: 'test_client_id' },


### PR DESCRIPTION
Being explicit about the auth strategy name since minification/transpilation can change the value of `constructor.name`.