### PR TITLE
fix: broken date comparison in memory session store

### DIFF
--- a/future-sir-frontend/app/.server/express/session.ts
+++ b/future-sir-frontend/app/.server/express/session.ts
@@ -127,7 +127,7 @@ function purgeExpiredSessions(memoryStore: MemoryStore): void {
         const expiresAt = sessionData.cookie.expires;
 
         log.trace('Checking session %s (expires at %s)', sessionId, expiresAt);
-        if (expiresAt && isPast(expiresAt)) {
+        if (expiresAt && isPast(new Date(expiresAt))) {
           log.trace('Purging expired session %s', sessionId);
           memoryStore.destroy(sessionId);
         }


### PR DESCRIPTION
There's a bug in express-session's memory session.. the cookie.expires attribute is serialized to a string during `set()`, but not deserialized during `get()` (despite the ts types saying it should be).