### PR TITLE
feat(frontend): add instance registry to handle singletons

### DIFF
--- a/frontend/app/.server/utils/instance-registry.ts
+++ b/frontend/app/.server/utils/instance-registry.ts
@@ -1,0 +1,27 @@
+import { AppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
+
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
+
+export const instanceNames = ['redisClient'] as const;
+
+export type InstanceName = (typeof instanceNames)[number];
+
+/**
+ * Retrieves a singleton instance. If the instance does not exist, it is created using the provided factory function.
+ *
+ * @throws {AppError} If the instance is not found and no factory function is provided.
+ */
+export function singleton<T>(instanceName: InstanceName, factory?: () => T): T {
+  globalThis.__instanceRegistry ??= new Map<InstanceName, unknown>();
+
+  if (!globalThis.__instanceRegistry.has(instanceName)) {
+    if (!factory) {
+      throw new AppError(`Instance [${instanceName}] not found and factory not provided`, ErrorCodes.NO_FACTORY_PROVIDED);
+    }
+
+    globalThis.__instanceRegistry.set(instanceName, factory());
+  }
+
+  return globalThis.__instanceRegistry.get(instanceName) as T;
+}

--- a/frontend/app/@types/global.d.ts
+++ b/frontend/app/@types/global.d.ts
@@ -1,6 +1,7 @@
 import type { RouteModules } from 'react-router';
 
 import type { ClientEnvironment } from '~/.server/environment';
+import type { InstanceName } from '~/.server/utils/instance-registry';
 
 /* eslint-disable no-var */
 
@@ -19,6 +20,11 @@ declare global {
    * Add the client-side environment to the global namespace.
    */
   var __appEnvironment: ClientEnvironment;
+
+  /**
+   * A holder for any application-scoped singletons.
+   */
+  var __instanceRegistry: Map<InstanceName, unknown>;
 
   /**
    * React Router adds the route modules to global

--- a/frontend/app/errors/error-codes.ts
+++ b/frontend/app/errors/error-codes.ts
@@ -13,6 +13,9 @@ export const ErrorCodes = {
   // i18n error codes
   NO_LANGUAGE_FOUND: 'I18N-0001',
 
+  // instance error codes
+  NO_FACTORY_PROVIDED: 'INST-0001',
+
   // route error codes
   ROUTE_NOT_FOUND: 'RTE-0001',
 


### PR DESCRIPTION
Add some code to handle application-scoped singletons. Useful for DB connection pools and other stuff you want to initialize just once.