### PR TITLE
fix(frontend): fix vitest deprecation warning

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -17,7 +17,8 @@
     "./react-router.config.ts",
     "./tailwind.config.ts",
     "./vite.config.ts",
-    "./vite.server.config.ts"
+    "./vite.server.config.ts",
+    "./vitest.workspace.ts"
   ],
   "compilerOptions": {
     "baseUrl": ".",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,12 +6,13 @@ import tailwindcss from 'tailwindcss';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
+// important: this must be a non-aliased (ie: not ~/) import
 import { preserveImportMetaUrl } from './vite.server.config';
 
 /**
  * This file is used to build the application.
+ * See vite.server.config.ts for the server build config.
  */
-
 export default defineConfig({
   css: {
     postcss: {
@@ -33,23 +34,16 @@ export default defineConfig({
       port: 3001,
     },
   },
+
+  //
+  // Vitest config. For more test configuration, see vitest.workspace.ts
+  // see: https://vitest.dev/config/
+  //
   test: {
     coverage: {
       // Includes only files within the `app` directory for test coverage reporting.
       include: ['**/app/**'],
     },
-    environmentMatchGlobs: [
-      // Maps specific test paths to test environments.
-      // Example: Components, hooks, and routes tests run in a `jsdom` environment to simulate a browser-like context.
-      ['**/tests/components/**', 'jsdom'],
-      ['**/tests/hooks/**', 'jsdom'],
-      ['**/tests/routes/**', 'jsdom'],
-    ],
-
-    // Specifies the file patterns to include as tests.
-    include: ['**/tests/**/*.test.(ts|tsx)'],
-
-    // Setup files to initialize the testing environment (global setup, mocks, etc).
     setupFiles: ['./tests/setup.ts'],
   },
 });

--- a/frontend/vitest.workspace.ts
+++ b/frontend/vitest.workspace.ts
@@ -1,0 +1,28 @@
+import { defineWorkspace } from 'vitest/config';
+
+/**
+ * see: https://vitest.dev/guide/workspace
+ */
+export default defineWorkspace([
+  {
+    extends: './vite.config.ts',
+    test: {
+      name: 'jsdom',
+      environment: 'jsdom',
+      include: [
+        '**/tests/components/**/*.test.(ts|tsx)',
+        '**/tests/hooks/**/*.test.(ts|tsx)',
+        '**/tests/routes/**/*.test.(ts|tsx)',
+      ],
+    },
+  },
+  {
+    extends: './vite.config.ts',
+    test: {
+      name: 'node',
+      environment: 'node',
+      include: ['**/tests/**/*.test.(ts|tsx)'],
+      exclude: ['**/tests/components/**', '**/tests/hooks/**', '**/tests/routes/**'],
+    },
+  },
+]);


### PR DESCRIPTION
The `environmentMatchGlobs` configuration option has been deprecated in Vite v6.x in favor of project workspaces. This PR creates two new vitest workspaces, `jsdom` and `node` that mimics the previously configured behavior.

## References

- <https://main.vitest.dev/config/#environmentmatchglobs>
- <https://vitest.dev/guide/workspace>