### PR TITLE
fix(gitops): fix misconfigured redis args

### DIFF
--- a/gitops/base/redis/stateful-sets.yaml
+++ b/gitops/base/redis/stateful-sets.yaml
@@ -42,7 +42,7 @@ spec:
           # Note: image tag should be pinned to a specific version in overlays
           #       ex: 7.2 in nonprod; 7.2.3 in prod
           image: docker.io/library/redis:7
-          args: [/data/redis.conf, --requirepass $(REDIS_PASSWORD), --masterauth $(REDIS_PASSWORD)]
+          args: [/data/redis.conf, --requirepass, $(REDIS_PASSWORD), --masterauth, $(REDIS_PASSWORD)]
           envFrom:
             - secretRef:
                 name: redis


### PR DESCRIPTION
Fix misconfigured (but accidentally working 😅) redis startup args.