### PR TITLE
feat(gitops): add otel configuration

### DIFF
--- a/gitops/base/future-sir-frontend/configs/config.conf
+++ b/gitops/base/future-sir-frontend/configs/config.conf
@@ -1,5 +1,6 @@
 # Controls the verbosity of log messages (default: info).
 # Valid values (from least to most verbose):
+#   - none: logs no messages
 #   - error: logs only error messages
 #   - warn: logs warnings and errors
 #   - info: logs general information, warnings, and errors
@@ -66,6 +67,10 @@ SESSION_COOKIE_PATH=
 #   - none: the cookie will be sent in all requests (requires Secure attribute to be true)
 SESSION_COOKIE_SAMESITE=
 
+# Secret key for signing and validating session cookies (default: 00000000-0000-0000-0000-000000000000).
+# Must be a strong, unique string of at least 32 characters. Keep this secure.
+# SESSION_COOKIE_SECRET=‼ set via k8s secret ‼
+
 # Specifies if the session cookie is marked as secure (default: true in production).
 # Note: Although the default is true in production mode, you can override it to false
 # for local development on localhost when testing with production-like settings.
@@ -74,7 +79,6 @@ SESSION_COOKIE_SECURE=
 # The session key prefix, if supported (default: SESSION:).
 # Currently only supported in the Redis session store.
 SESSION_KEY_PREFIX=
-
 
 
 #################################################
@@ -97,6 +101,10 @@ REDIS_PORT=
 # Provide a username if your Redis setup requires username/password authentication.
 REDIS_USERNAME=
 
+# Password for Redis authentication (optional).
+# Provide a password if your Redis setup requires username/password or just password authentication.
+# REDIS_PASSWORD=‼ set via k8s secret ‼
+
 # Command timeout for Redis operations in seconds (default: 1).
 # Specifies the maximum time to wait before a command times out.
 REDIS_COMMAND_TIMEOUT_SECONDS=
@@ -112,13 +120,16 @@ REDIS_SENTINEL_MASTER_NAME=
 #################################################
 
 # The name of this service (default: Future SIR frontend).
-OTEL_SERVICE_NAME=
+# OTEL_SERVICE_NAME=‼ set in container image at build time ‼
 
 # The version of this service (default: 0.0.0).
-OTEL_SERVICE_VERSION=
+# OTEL_SERVICE_VERSION=‼ set in container image at build time ‼
 
 # Name of the deployment environment (default: localhost).
 OTEL_ENVIRONMENT_NAME=
+
+# Autentication header name (default: Authorization 00000000-0000-0000-0000-000000000000).
+# OTEL_AUTH_HEADER=‼ set via k8s secret ‼
 
 # URL to ship metrics to (default: http://localhost:4318/v1/metrics).
 OTEL_METRICS_ENDPOINT=
@@ -151,3 +162,7 @@ AZUREAD_ISSUER_URL=
 # The Azure AD client ID.
 # This identifies your application when interacting with Azure AD.
 AZUREAD_CLIENT_ID=
+
+# The Azure AD client secret.
+# This is used to authenticate your application with Azure AD.
+AZUREAD_CLIENT_SECRET=‼ set via k8s secret ‼

--- a/gitops/overlays/dev/configs/future-sir-frontend/config.conf
+++ b/gitops/overlays/dev/configs/future-sir-frontend/config.conf
@@ -1,5 +1,6 @@
 # Controls the verbosity of log messages (default: info).
 # Valid values (from least to most verbose):
+#   - none: logs no messages
 #   - error: logs only error messages
 #   - warn: logs warnings and errors
 #   - info: logs general information, warnings, and errors
@@ -66,6 +67,10 @@ SESSION_COOKIE_PATH=
 #   - none: the cookie will be sent in all requests (requires Secure attribute to be true)
 SESSION_COOKIE_SAMESITE=
 
+# Secret key for signing and validating session cookies (default: 00000000-0000-0000-0000-000000000000).
+# Must be a strong, unique string of at least 32 characters. Keep this secure.
+# SESSION_COOKIE_SECRET=‼ set via k8s secret ‼
+
 # Specifies if the session cookie is marked as secure (default: true in production).
 # Note: Although the default is true in production mode, you can override it to false
 # for local development on localhost when testing with production-like settings.
@@ -74,7 +79,6 @@ SESSION_COOKIE_SECURE=
 # The session key prefix, if supported (default: SESSION:).
 # Currently only supported in the Redis session store.
 SESSION_KEY_PREFIX=SESSION:DEV:
-
 
 
 #################################################
@@ -97,6 +101,10 @@ REDIS_PORT=26379
 # Provide a username if your Redis setup requires username/password authentication.
 REDIS_USERNAME=
 
+# Password for Redis authentication (optional).
+# Provide a password if your Redis setup requires username/password or just password authentication.
+# REDIS_PASSWORD=‼ set via k8s secret ‼
+
 # Command timeout for Redis operations in seconds (default: 1).
 # Specifies the maximum time to wait before a command times out.
 REDIS_COMMAND_TIMEOUT_SECONDS=
@@ -111,14 +119,23 @@ REDIS_SENTINEL_MASTER_NAME=myprimary
 # Authenication configuration
 #################################################
 
+# The name of this service (default: Future SIR frontend).
+# OTEL_SERVICE_NAME=‼ set in container image at build time ‼
+
+# The version of this service (default: 0.0.0).
+# OTEL_SERVICE_VERSION=‼ set in container image at build time ‼
+
 # Name of the deployment environment (default: localhost).
-OTEL_ENVIRONMENT_NAME=development
+OTEL_ENVIRONMENT_NAME=dev
+
+# Autentication header name (default: Authorization 00000000-0000-0000-0000-000000000000).
+# OTEL_AUTH_HEADER=‼ set via k8s secret ‼
 
 # URL to ship metrics to (default: http://localhost:4318/v1/metrics).
-OTEL_METRICS_ENDPOINT=
+OTEL_METRICS_ENDPOINT=https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b-4d9b-aa87-ee5f8b79f8c9/api/v2/otlp/v1/metrics
 
 # URL to ship traces to (default: http://localhost:4318/v1/traces).
-OTEL_TRACES_ENDPOINT=
+OTEL_TRACES_ENDPOINT=https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b-4d9b-aa87-ee5f8b79f8c9/api/v2/otlp/v1/traces
 
 
 
@@ -130,7 +147,7 @@ OTEL_TRACES_ENDPOINT=
 # Valid values:
 #   - azuread: uses Azure Active Directory for authentication
 #   - local: use a local mock OIDC provider
-AUTH_DEFAULT_PROVIDER=azuread
+AUTH_DEFAULT_PROVIDER=
 
 
 
@@ -145,3 +162,7 @@ AZUREAD_ISSUER_URL=https://login.microsoftonline.com/9ed55846-8a81-4246-acd8-b1a
 # The Azure AD client ID.
 # This identifies your application when interacting with Azure AD.
 AZUREAD_CLIENT_ID=fb240ef1-76a1-42a5-abcb-1d95ec0d6a0e
+
+# The Azure AD client secret.
+# This is used to authenticate your application with Azure AD.
+# AZUREAD_CLIENT_SECRET=‼ set via k8s secret ‼

--- a/gitops/overlays/dev/external-secrets.yaml
+++ b/gitops/overlays/dev/external-secrets.yaml
@@ -9,10 +9,19 @@ spec:
   secretStoreRef:
     name: vault-backend
     kind: SecretStore
+  target:
+    template:
+      data:
+        AZUREAD_CLIENT_SECRET: '{{ .AZUREAD_CLIENT_SECRET }}'
+        OTEL_AUTH_HEADER: 'Api-Token {{ .OTEL_AUTH_HEADER }}'
+        REDIS_PASSWORD: '{{ .REDIS_PASSWORD }}'
+        SESSION_COOKIE_SECRET: '{{ .SESSION_COOKIE_SECRET  }}'
   data:
     - secretKey: AZUREAD_CLIENT_SECRET
       remoteRef: { key: dev, property: AZUREAD_CLIENT_SECRET }
-    - secretKey: SESSION_COOKIE_SECRET
-      remoteRef: { key: dev, property: SESSION_COOKIE_SECRET }
+    - secretKey: OTEL_AUTH_HEADER
+      remoteRef: { key: dev, property: DT_ACCESS_TOKEN }
     - secretKey: REDIS_PASSWORD
       remoteRef: { key: shared, property: REDIS_PASSWORD }
+    - secretKey: SESSION_COOKIE_SECRET
+      remoteRef: { key: dev, property: SESSION_COOKIE_SECRET }


### PR DESCRIPTION
Depends on #78

Add Dynatrace OpenTelemetry configuration to gitops manifests. Note that this is mostly working, but some further configuration needs to be done in the frontend `containerfile` to get some of the OTel metadata to be correctly reported.

![image](https://github.com/user-attachments/assets/505070c0-a16a-4425-9038-dce1558e4ba1)

Note that I also updated the base config template to match the latest `.env.example` file.