### PR TITLE
fix(frontend): fix otel config

### DIFF
--- a/frontend/app/.server/environment/telemetry.ts
+++ b/frontend/app/.server/environment/telemetry.ts
@@ -5,7 +5,7 @@ import * as ValidationUtils from '~/utils/validation-utils';
 export type Telemetry = Readonly<z.infer<typeof telemetry>>;
 
 export const defaults = {
-  OTEL_SERVICE_NAME: 'Future SIR frontend',
+  OTEL_SERVICE_NAME: 'future-sir-frontend',
   OTEL_SERVICE_VERSION: '0.0.0',
   OTEL_ENVIRONMENT_NAME: 'localhost',
   OTEL_AUTH_HEADER: 'Authorization 00000000-0000-0000-0000-000000000000',


### PR DESCRIPTION
While integrating with Dynatrace, I discovered that the default service name in `app/.server/environment/telemetry.ts` causes a 400 response from the Dynatrace API.