### PR TITLE
fix(frontend): Error when using sourcemap for reporting an error

### DIFF
--- a/frontend/app/components/dropdown-menu.tsx
+++ b/frontend/app/components/dropdown-menu.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import * as React from 'react';
 
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';


### PR DESCRIPTION
Fixes the following error when building.

```
app/components/dropdown-menu.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
```

![image](https://github.com/user-attachments/assets/f9932246-5c77-40d3-86a8-683384117a6d)

@Dario-Au `'use client';` directive copied from [shadcn/ui](https://ui.shadcn.com/) works with Next.js and not with React Router. I didn't caught that when I reviewed your PR.

https://nextjs.org/docs/app/api-reference/directives/use-client