### PR TITLE
fix(frondend): fix "possible EventEmitter memory leak detected"

### DIFF
--- a/frontend/app/.server/express/server.ts
+++ b/frontend/app/.server/express/server.ts
@@ -11,6 +11,15 @@ import { LogFactory } from '~/.server/logging';
 
 const log = LogFactory.getLogger(import.meta.url);
 
+// accommodate the extra uncaughtException and unhandledRejection listeners
+// added by winston by increasing the max number of listeners by 25%
+// see: https://github.com/winstonjs/winston/blob/v3.17.0/lib/winston/exception-handler.js#L51
+// see: https://github.com/winstonjs/winston/blob/v3.17.0/lib/winston/rejection-handler.js#L51
+const existingMaxListeners = process.getMaxListeners();
+const increasedMaxListeners = Math.round(existingMaxListeners * 1.25);
+log.debug('Setting process.maxListeners to to %s (was: %s)', increasedMaxListeners, existingMaxListeners);
+process.setMaxListeners(increasedMaxListeners);
+
 log.info('Installing source map support');
 sourceMapSupport.install();
 

--- a/frontend/app/.server/logging.ts
+++ b/frontend/app/.server/logging.ts
@@ -17,7 +17,11 @@ export const logLevels = {
   trace: 6,
 } as const;
 
-const consoleTransport = new transports.Console();
+const consoleTransport = new transports.Console({
+  handleExceptions: true,
+  handleRejections: true,
+  level: getLogLevel(),
+});
 
 export const LogFactory = {
   /**
@@ -32,7 +36,6 @@ export const LogFactory = {
     }
 
     return winston.loggers.add(category, {
-      level: getLogLevel(),
       levels: logLevels,
       format: format.combine(
         format.label({ label: category }),
@@ -41,8 +44,6 @@ export const LogFactory = {
         fullFormat({ stack: true }),
         format.printf(asFormattedInfo),
       ),
-      exceptionHandlers: [consoleTransport],
-      rejectionHandlers: [consoleTransport],
       transports: [consoleTransport],
     });
   },


### PR DESCRIPTION
This PR fixes the following warning that is printed during application startup:

```
(node:1166207) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 uncaughtException listeners added to [process]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit
    at genericNodeError (node:internal/errors:983:15)
    at wrappedFn (node:internal/errors:537:14)
    at _addListener (node:events:598:17)
    at process.addListener (node:events:616:10)
    at ExceptionHandler.handle (/home/gbaker/Projects/github/dts-stn/future-sir/frontend/node_modules/winston/lib/winston/exception-handler.js:51:15)
    at DerivedLogger.add (/home/gbaker/Projects/github/dts-stn/future-sir/frontend/node_modules/winston/lib/winston/logger.js:368:23)
    at /home/gbaker/Projects/github/dts-stn/future-sir/frontend/node_modules/winston/lib/winston/logger.js:124:44
    at Array.forEach (<anonymous>)
    at DerivedLogger.configure (/home/gbaker/Projects/github/dts-stn/future-sir/frontend/node_modules/winston/lib/winston/logger.js:124:18)
    at new Logger (/home/gbaker/Projects/github/dts-stn/future-sir/frontend/node_modules/winston/lib/winston/logger.js:42:10)
(node:1166207) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 unhandledRejection listeners added to [process]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit
    at genericNodeError (node:internal/errors:983:15)
    at wrappedFn (node:internal/errors:537:14)
    at _addListener (node:events:598:17)
    at process.addListener (node:events:616:10)
    at RejectionHandler.handle (/home/gbaker/Projects/github/dts-stn/future-sir/frontend/node_modules/winston/lib/winston/rejection-handler.js:51:15)
    at DerivedLogger.add (/home/gbaker/Projects/github/dts-stn/future-sir/frontend/node_modules/winston/lib/winston/logger.js:372:23)
    at /home/gbaker/Projects/github/dts-stn/future-sir/frontend/node_modules/winston/lib/winston/logger.js:124:44
    at Array.forEach (<anonymous>)
    at DerivedLogger.configure (/home/gbaker/Projects/github/dts-stn/future-sir/frontend/node_modules/winston/lib/winston/logger.js:124:18)
    at new Logger (/home/gbaker/Projects/github/dts-stn/future-sir/frontend/node_modules/winston/lib/winston/logger.js:42:10)
```

Increasing the `maxListeners` to 11 would have fixed the problem, but I opted to increase the number by 25% just to have a buffer for the future.