### PR TITLE
fix(frontend): add `tmp/` to `.gitignore`

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -172,4 +172,5 @@ dist
 build/
 playwright-report/
 test-results/
+tmp/
 vite.config.ts.timestamp-*


### PR DESCRIPTION
The mainline build job is failing in TeamCity because prettier doesn't like the kubeconfig.yaml file that the job creates in `tmp/`. Explicitly adding the `tmp/` directory to `.gitignore` fixes this.