### PR TITLE
fix(frontend): fix broken express 500 page

### DIFF
--- a/frontend/app/.server/express/middleware.ts
+++ b/frontend/app/.server/express/middleware.ts
@@ -72,14 +72,14 @@ export function security(environment: ServerEnvironment): RequestHandler {
       `base-uri 'none'`,
       `default-src 'none'`,
       `connect-src 'self'` + (environment.isProduction ? '' : ' ws://localhost:3001'),
-      `font-src 'self' fonts.gstatic.com`,
+      `font-src 'self' fonts.gstatic.com use.fontawesome.com www.canada.ca`,
       `form-action 'self'`,
       `frame-ancestors 'self'`,
       `frame-src 'self'`,
-      `img-src 'self' https://www.canada.ca`,
+      `img-src 'self' www.canada.ca`,
       `object-src data:`,
       `script-src 'self' 'nonce-${response.locals.nonce}'`,
-      `style-src 'self' fonts.googleapis.com`,
+      `style-src 'self' fonts.googleapis.com use.fontawesome.com www.canada.ca`,
     ].join('; ');
 
     const permissionsPolicy = [


### PR DESCRIPTION
Recent changes to the page html has caused the express-level 500 page to break. This page is rendered whenever React Router throws outside of its error boundary.

**Before:**

![localhost_3000_en_public](https://github.com/user-attachments/assets/4c9ed5aa-246e-4bb0-acb4-59614c1d3a9f)

**After:**

![localhost_3000_en_public (1)](https://github.com/user-attachments/assets/b4fa6ee6-19c4-4fde-a7f2-cf8878a40679)
