### PR TITLE
fix(frontend): fix broken `entry.server.tsx` error handler

### DIFF
--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -88,7 +88,6 @@ export default async function handleRequest(
 // https://reactrouter.com/explanation/special-files#handleerror
 export function handleError(error: unknown, { context, params, request }: LoaderFunctionArgs | ActionFunctionArgs) {
   if (!request.signal.aborted) {
-    const log = context.LogFactory.getLogger(import.meta.url);
     log.error('Uncaught error while handling request:', error);
     handleSpanException(error, trace.getActiveSpan());
   }


### PR DESCRIPTION
A bad `getLogger()` line in `entry.server.tsx` was throwing, causing all errors to be misreported in the logging console.

**Before:**

```
2025-01-15T11:46:46.705Z   ERROR --- […rver/express/handlers.ts]: Unexpected error caught by express server Cannot read properties of undefined (reading 'getLogger') --- {
  stack: "TypeError: Cannot read properties of undefined (reading 'getLogger')\n" +
    '    at handleError (/home/gbaker/Projects/github/dts-stn/future-sir/frontend/app/entry.server.tsx:64:37)\n' +
...
```

**After:**

```
2025-01-15T11:47:04.449Z   ERROR --- [     app/entry.server.tsx]: Uncaught error while handling request: --- {
  name: 'AppError',
  errorCode: 'RTE-0001',
  correlationId: 'J4-GX3W29',
  httpStatusCode: 500,
  msg: 'No route found for /en/public/wizard/ (this should never happen)',
  ...
```