### PR TITLE
first name screen

### DIFF
--- a/frontend/app/routes/protected/person-case/first-name.tsx
+++ b/frontend/app/routes/protected/person-case/first-name.tsx
@@ -1,45 +1,98 @@
-import { Form } from 'react-router';
+import { data, useFetcher } from 'react-router';
 import type { RouteHandle } from 'react-router';
 
 import { useTranslation } from 'react-i18next';
+import * as v from 'valibot';
 
+import type { Route, Info } from './+types/first-name';
+
+import { requireAuth } from '~/.server/utils/auth-utils';
+import { i18nRedirect } from '~/.server/utils/route-utils';
+import { firstNameSchema } from '~/.server/validation';
 import { Button } from '~/components/button';
+import { ButtonLink } from '~/components/button-link';
+import { ErrorSummary } from '~/components/error-summary';
 import { InputField } from '~/components/input-field';
 import { PageTitle } from '~/components/page-title';
+import { getFixedT } from '~/i18n-config.server';
 import { handle as parentHandle } from '~/routes/protected/layout';
+import { getLanguage } from '~/utils/i18n-utils';
 
 export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace, 'protected'],
 } as const satisfies RouteHandle;
 
-export default function FirstName() {
+export async function loader({ context, request }: Route.LoaderArgs) {
+  requireAuth(context.session, new URL(request.url), ['user']);
+  const t = await getFixedT(request, handle.i18nNamespace);
+
+  return {
+    documentTitle: t('protected:person-case.page-title'),
+    defaultValue: {
+      firstName: context.session.inPersonSINCase?.firstName,
+    },
+  };
+}
+
+export const meta: Route.MetaFunction = ({ data }) => {
+  return [{ title: data.documentTitle }];
+};
+
+export async function action({ context, request }: Route.ActionArgs) {
+  requireAuth(context.session, new URL(request.url), ['user']);
+  const lang = getLanguage(request);
+
+  const formData = await request.formData();
+  const input = { firstName: formData.get('first-name') as string };
+
+  // Validation schema
+  const schema = v.object({ firstName: firstNameSchema() });
+
+  // Safe-parse form data input
+  const parsedDataResult = v.safeParse(schema, input, { lang });
+
+  if (!parsedDataResult.success) {
+    return data({ errors: v.flatten<typeof schema>(parsedDataResult.issues).nested }, { status: 400 });
+  }
+  // If the first name is valid, store it in the session and redirect to the next page
+
+  context.session.inPersonSINCase = {
+    ...(context.session.inPersonSINCase ?? {}),
+    ...input,
+  };
+  return i18nRedirect('routes/protected/person-case/last-name.tsx', request);
+}
+
+export default function FirstName({ loaderData, actionData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespace);
+
+  const fetcher = useFetcher<Info['actionData']>();
+  const isSubmitting = fetcher.state !== 'idle';
+  const errors = fetcher.data?.errors;
 
   return (
     <>
-      <div className="mb-8">
-        <PageTitle className="mt-8">{t('protected:person-case.page-title')}</PageTitle>
-        <Form id="first-name-form" method="post">
-          <InputField
-            className="mb-4"
-            id="first-name-id"
-            label={t('protected:person-case.first-name')}
-            name="first-name"
-            required
-            type="text"
-          />
-          <div className="space-x-2">
-            <Button>{t('protected:person-case.previous')}</Button>
-            <Button>{t('protected:person-case.next')}</Button>
-          </div>
-        </Form>
-      </div>
+      <PageTitle className="mb-8">{t('protected:person-case.page-title')}</PageTitle>
+      <ErrorSummary errors={errors} />
+      <fetcher.Form method="post" noValidate>
+        <InputField
+          id="first-name-id"
+          errorMessage={errors?.firstName?.at(0)}
+          label={t('protected:person-case.first-name')}
+          name="first-name"
+          defaultValue={loaderData.defaultValue.firstName}
+          required
+          type="text"
+        />
+        <div className="mt-8 flex flex-wrap items-center gap-3">
+          <ButtonLink id="back-button" file="routes/protected/index.tsx" params={params} disabled={isSubmitting}>
+            {t('protected:person-case.previous')}
+          </ButtonLink>
+          <Button variant="primary" type="submit" id="continue-first-name-button" disabled={isSubmitting}>
+            {t('protected:person-case.next')}
+          </Button>
+        </div>
+      </fetcher.Form>
     </>
   );
-}
-
-export function action() {
-  return {
-    title: 'First Name',
-  };
 }

--- a/frontend/app/routes/protected/person-case/last-name.tsx
+++ b/frontend/app/routes/protected/person-case/last-name.tsx
@@ -58,16 +58,14 @@ export default function LastName({ actionData, params }: Route.ComponentProps) {
       <PageTitle className="mb-8">{t('protected:person-case.page-title')}</PageTitle>
       <ErrorSummary errors={errors} />
       <fetcher.Form method="post" noValidate>
-        <div className="space-y-6">
-          <InputField
-            id="last-name-id"
-            label={t('protected:person-case.last-name')}
-            name="last-name"
-            required
-            type="text"
-            errorMessage={errors?.lastName?.at(0)}
-          />
-        </div>
+        <InputField
+          id="last-name-id"
+          label={t('protected:person-case.last-name')}
+          name="last-name"
+          required
+          type="text"
+          errorMessage={errors?.lastName?.at(0)}
+        />
         <div className="mt-8 flex flex-wrap items-center gap-3">
           <ButtonLink
             id="back-button"


### PR DESCRIPTION
## Summary
Updated the first name screen, upon successful validation, save the input in the session object and redirect the user to "last-name" screen.
When the screen loads, attempt to retrieve the default value for the First Name text field from the session.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)


## Screenshots (if applicable)
First Name is loaded from session: 
![image](https://github.com/user-attachments/assets/be96d4a7-1581-49f0-8312-dd3aae79d3bd)
