### PR TITLE
feat(frontend): add `useTabId()` hook

### DIFF
--- a/frontend/app/hooks/use-tab-id.ts
+++ b/frontend/app/hooks/use-tab-id.ts
@@ -1,0 +1,107 @@
+import { useEffect, useSyncExternalStore } from 'react';
+
+import { useLocation, useNavigate } from 'react-router';
+
+import { randomString } from '~/utils/string-utils';
+
+export const SEARCH_PARAM_KEY = 'tid';
+export const SESSION_STORAGE_KEY = 'tab-id';
+
+/**
+ * Generates a random tab identifier in the format `xx-0000`.
+ * This id will uniquely identify different tabs within the same browser instance.
+ */
+function generateRandomId(): string {
+  const prefix = randomString(2, 'abcdefghijklmnopqrstuvwxyz');
+  const suffix = randomString(4, '0123456789');
+  return `${prefix}-${suffix}`;
+}
+
+/**
+ * Retrieves the current tab id from session storage or generates a new one if not found.
+ * Ensures the tab id persists across page reloads within the same tab.
+ */
+function getSnapshot(sessionStorageKey: string): string {
+  const id = window.sessionStorage.getItem(sessionStorageKey) ?? generateRandomId();
+  window.sessionStorage.setItem(sessionStorageKey, id); // store the id to persist it across reloads
+  return id;
+}
+
+/**
+ * Subscribes to `storage` events to detect changes in session storage.
+ * If the tab id in session storage changes (e.g., via tampering),
+ * it triggers a re-render by calling the provided callback.
+ */
+function subscribe(sessionStorageKey: string, callback: () => void): () => void {
+  const handler = ({ key }: StorageEvent): void => {
+    if (key === sessionStorageKey) {
+      callback(); // trigger a state update only if the session storage key changes
+    }
+  };
+
+  window.addEventListener('storage', handler);
+  return () => window.removeEventListener('storage', handler);
+}
+
+type Options = {
+  /**
+   * Whether to automatically update the URL with the tab id as a query parameter.
+   * Defaults to `true`.
+   */
+  navigate?: false;
+  /**
+   * The query parameter key used for storing the tab id in the URL.
+   * Defaults to `'tid'`.
+   */
+  searchParamKey?: string;
+  /**
+   * The session storage key used for persisting the tab id.
+   * Defaults to `'tab-id'`.
+   */
+  sessionStorageKey?: string;
+};
+
+/**
+ * React hook that provides a unique, persistent identifier for the current browser tab.
+ *
+ * - The id persists across page reloads but resets when the tab is closed.
+ * - If `navigate` is enabled (default: `true`), the hook ensures the id is present in the URL.
+ * - The id is stored in `sessionStorage`, ensuring it remains unique per tab.
+ * - Uses `useSyncExternalStore` to listen for changes in session storage and re-render accordingly.
+ *
+ * @param options Configuration options for customizing behavior.
+ * @returns The unique tab id for the current browser tab, or `undefined` on first render.
+ */
+export function useTabId(options?: Options): string | undefined {
+  const {
+    navigate = true, //
+    searchParamKey = SEARCH_PARAM_KEY,
+    sessionStorageKey = SESSION_STORAGE_KEY,
+  } = options ?? {};
+
+  const { search } = useLocation();
+  const navigateFn = useNavigate();
+
+  const searchParamId = new URLSearchParams(search).get(searchParamKey);
+
+  // fetch the current tab id from session storage
+  // this will often be undefined on first access
+  const id = useSyncExternalStore(
+    (callback) => subscribe(sessionStorageKey, callback),
+    () => getSnapshot(sessionStorageKey),
+    () => searchParamId ?? undefined,
+  );
+
+  useEffect(() => {
+    if (navigate) {
+      if (id !== undefined && id !== searchParamId) {
+        // if the tab id in session storage doesn't match the URL, update the URL
+        const urlSearchParams = new URLSearchParams(search);
+        urlSearchParams.set(searchParamKey, id);
+        void navigateFn({ search: urlSearchParams.toString() });
+      }
+    }
+  }, [id, navigate, search]);
+
+  return id;
+}

--- a/frontend/tests/hooks/use-tab-id.test.tsx
+++ b/frontend/tests/hooks/use-tab-id.test.tsx
@@ -1,0 +1,53 @@
+import { MemoryRouter, useLocation } from 'react-router';
+
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { SESSION_STORAGE_KEY, useTabId } from '~/hooks/use-tab-id';
+
+describe('use-tab-id', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => <MemoryRouter>{children}</MemoryRouter>;
+
+  it('should generate a new tab id if none exists in session storage', () => {
+    window.sessionStorage.removeItem(SESSION_STORAGE_KEY);
+
+    const { result } = renderHook(() => ({ location: useLocation(), tabId: useTabId() }), { wrapper });
+
+    expect(result.current.tabId).toMatch(/[a-z]{2}-[0-9]{4}/);
+    expect(window.sessionStorage.getItem(SESSION_STORAGE_KEY)).toEqual(result.current.tabId);
+  });
+
+  it('should update the URL if it does not match existing tab id', () => {
+    window.sessionStorage.setItem(SESSION_STORAGE_KEY, 'xx-0000');
+
+    const { result } = renderHook(() => ({ location: useLocation(), tabId: useTabId() }), { wrapper });
+
+    expect(result.current.tabId).toEqual('xx-0000');
+    expect(result.current.location.search).toContain('tid=xx-0000');
+  });
+
+  it('should not update the URL if options.navigate=false', () => {
+    window.sessionStorage.setItem(SESSION_STORAGE_KEY, 'xx-0000');
+
+    const { result } = renderHook(() => ({ location: useLocation(), tabId: useTabId({ navigate: false }) }), { wrapper });
+
+    expect(result.current.tabId).toEqual('xx-0000');
+    expect(result.current.location.search).not.toContain('tid=xx-0000');
+  });
+
+  it('should re-render when session storage changes', () => {
+    window.sessionStorage.setItem(SESSION_STORAGE_KEY, 'xx-0000');
+
+    const { result } = renderHook(() => ({ location: useLocation(), tabId: useTabId() }), { wrapper });
+
+    expect(result.current.tabId).toEqual('xx-0000');
+
+    act(() => {
+      window.sessionStorage.setItem(SESSION_STORAGE_KEY, 'xx-1111');
+      window.dispatchEvent(new StorageEvent('storage', { key: SESSION_STORAGE_KEY }));
+    });
+
+    expect(result.current.tabId).toEqual('xx-1111');
+    expect(result.current.location.search).toContain('tid=xx-1111');
+  });
+});


### PR DESCRIPTION
## Summary

Add a `useTabId()` hook that can be used isolate session data per-tab/window.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Screenshots

Here is a small video of the tab id being generated and then added to the URL (so it can be used server-side).

[Screencast from 2025-01-30 09-25-04.webm](https://github.com/user-attachments/assets/3939e808-1cee-47f3-bba8-0acd7e85cd17)
