### PR TITLE
fix(frontend): persist search params across language toggle

### DIFF
--- a/frontend/app/components/language-switcher.tsx
+++ b/frontend/app/components/language-switcher.tsx
@@ -1,5 +1,7 @@
 import type { ComponentProps } from 'react';
 
+import { useLocation } from 'react-router';
+
 import { InlineLink } from '~/components/links';
 import { useLanguage } from '~/hooks/use-language';
 import { useRoute } from '~/hooks/use-route';
@@ -10,6 +12,7 @@ type LanguageSwitcherProps = Omit<ComponentProps<typeof InlineLink>, 'file' | 'l
 
 export function LanguageSwitcher({ className, children, ...props }: LanguageSwitcherProps) {
   const { altLanguage } = useLanguage();
+  const { search } = useLocation();
   const { file } = useRoute();
 
   return (
@@ -18,6 +21,7 @@ export function LanguageSwitcher({ className, children, ...props }: LanguageSwit
       file={file as I18nRouteFile}
       lang={altLanguage}
       reloadDocument={true}
+      search={search}
       {...props}
     >
       {children}


### PR DESCRIPTION
## Summary

This PR adds a fix to the `<LanguageSwitcher>` component that ensures querystring params are persisted across language toggles.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>
