### PR TITLE
feat(frontend): add XState and initial FSM+tests

### DIFF
--- a/frontend/app/routes/protected/in-person/state-machine.ts
+++ b/frontend/app/routes/protected/in-person/state-machine.ts
@@ -1,0 +1,95 @@
+import { setup } from 'xstate';
+
+type Event = { type: 'prev' } | { type: 'next' } | { type: 'cancel' };
+
+export const machine = setup({
+  types: {
+    events: {} as Event,
+  },
+}).createMachine({
+  id: '(in-person-machine)',
+  initial: 'start',
+  states: {
+    'start': {
+      on: {
+        next: { target: 'privacy-statement' },
+      },
+    },
+    'privacy-statement': {
+      on: {
+        prev: { target: 'start' },
+        next: { target: 'request-details' },
+        cancel: { target: 'start' },
+      },
+    },
+    'request-details': {
+      on: {
+        prev: { target: 'privacy-statement' },
+        next: { target: 'primary-docs' },
+        cancel: { target: 'start' },
+      },
+    },
+    'primary-docs': {
+      on: {
+        prev: { target: 'request-details' },
+        next: { target: 'secondary-docs' },
+        cancel: { target: 'start' },
+      },
+    },
+    'secondary-docs': {
+      on: {
+        prev: { target: 'primary-docs' },
+        next: { target: 'name-info' },
+        cancel: { target: 'start' },
+      },
+    },
+    'name-info': {
+      on: {
+        prev: { target: 'secondary-docs' },
+        next: { target: 'personal-info' },
+        cancel: { target: 'start' },
+      },
+    },
+    'personal-info': {
+      on: {
+        prev: { target: 'name-info' },
+        next: { target: 'birth-info' },
+        cancel: { target: 'start' },
+      },
+    },
+    'birth-info': {
+      on: {
+        prev: { target: 'personal-info' },
+        next: { target: 'parent-info' },
+        cancel: { target: 'start' },
+      },
+    },
+    'parent-info': {
+      on: {
+        prev: { target: 'birth-info' },
+        next: { target: 'previous-sin-info' },
+        cancel: { target: 'start' },
+      },
+    },
+    'previous-sin-info': {
+      on: {
+        prev: { target: 'parent-info' },
+        next: { target: 'contact-info' },
+        cancel: { target: 'start' },
+      },
+    },
+    'contact-info': {
+      on: {
+        prev: { target: 'previous-sin-info' },
+        next: { target: 'review' },
+        cancel: { target: 'start' },
+      },
+    },
+    'review': {
+      on: {
+        cancel: { target: 'start' },
+        // TODO --- rest of events
+      },
+    },
+  },
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -55,6 +55,7 @@
         "validator": "^13.12.0",
         "winston": "^3.17.0",
         "winston-error-format": "^3.0.1",
+        "xstate": "^5.19.2",
         "zod": "^3.24.1"
       },
       "devDependencies": {
@@ -14238,6 +14239,16 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xstate": {
+      "version": "5.19.2",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-5.19.2.tgz",
+      "integrity": "sha512-B8fL2aP0ogn5aviAXFzI5oZseAMqN00fg/TeDa3ZtatyDcViYLIfuQl4y8qmHCiKZgGEzmnTyNtNQL9oeJE2gw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/xstate"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,6 +68,7 @@
     "validator": "^13.12.0",
     "winston": "^3.17.0",
     "winston-error-format": "^3.0.1",
+    "xstate": "^5.19.2",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/frontend/tests/routes/protected/in-person/state-machine.test.ts
+++ b/frontend/tests/routes/protected/in-person/state-machine.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { createActor } from 'xstate';
+
+import { machine } from '~/routes/protected/in-person/state-machine';
+
+describe('in-person machine transitions', () => {
+  const states = [
+    'start',
+    'privacy-statement',
+    'request-details',
+    'primary-docs',
+    'secondary-docs',
+    'name-info',
+    'personal-info',
+    'birth-info',
+    'parent-info',
+    'previous-sin-info',
+    'contact-info',
+    'review',
+  ] as const;
+
+  const prevStates = Object.entries({
+    'privacy-statement': 'start',
+    'request-details': 'privacy-statement',
+    'primary-docs': 'request-details',
+    'secondary-docs': 'primary-docs',
+    'name-info': 'secondary-docs',
+    'personal-info': 'name-info',
+    'birth-info': 'personal-info',
+    'parent-info': 'birth-info',
+    'previous-sin-info': 'parent-info',
+    'contact-info': 'previous-sin-info',
+  } as const);
+
+  const nextStates = Object.entries({
+    'start': 'privacy-statement',
+    'privacy-statement': 'request-details',
+    'request-details': 'primary-docs',
+    'primary-docs': 'secondary-docs',
+    'secondary-docs': 'name-info',
+    'name-info': 'personal-info',
+    'personal-info': 'birth-info',
+    'birth-info': 'parent-info',
+    'parent-info': 'previous-sin-info',
+    'previous-sin-info': 'contact-info',
+    'contact-info': 'review',
+  } as const);
+
+  it.each(nextStates)('should transition from %s to %s on next event', (from, to) => {
+    const state = machine.resolveState({ value: from });
+    const actor = createActor(machine, { state }).start();
+
+    actor.send({ type: 'next' });
+
+    expect(actor.getSnapshot().value).toEqual(to);
+  });
+
+  it.each(prevStates)('should transition from %s to %s on prev event', (from, to) => {
+    const state = machine.resolveState({ value: from });
+    const actor = createActor(machine, { state }).start();
+
+    actor.send({ type: 'prev' });
+
+    expect(actor.getSnapshot().value).toEqual(to);
+  });
+
+  it.each(states.filter((state) => state !== 'start'))('should transition from %s to start on cancel', (from) => {
+    const state = machine.resolveState({ value: from });
+    const actor = createActor(machine, { state }).start();
+
+    actor.send({ type: 'cancel' });
+
+    expect(actor.getSnapshot().value).toEqual('start');
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds XState to the project and configures a very simple state machine that can navigate from one state to another when `next`, `prev`, and `cancel` events are emitted.

The flow logic follows <https://www.figma.com/design/eFeAwkp1LCalkB5q7CZxaV/FSIR> and more functionality will be added in future PRs.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [x] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>
