### PR TITLE
fix(frontend): set `replace: true` in `useTabId()` hook navigation

### DIFF
--- a/frontend/app/hooks/use-tab-id.ts
+++ b/frontend/app/hooks/use-tab-id.ts
@@ -98,7 +98,7 @@ export function useTabId(options?: Options): string | undefined {
         // if the tab id in session storage doesn't match the URL, update the URL
         const urlSearchParams = new URLSearchParams(search);
         urlSearchParams.set(searchParamKey, id);
-        void navigateFn({ search: urlSearchParams.toString() });
+        void navigateFn({ search: urlSearchParams.toString() }, { replace: true });
       }
     }
   }, [id, navigate, search]);


### PR DESCRIPTION
## Summary

The option `{ replace: true }` should be set during navigation in the `useTabId()` hook to ensure that we don't break back/forward browser buttons. Without `{ replace: true }`, it is difficult to navigate back to the previous page because the application  will immediately navigate forward again.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>
