### PR TITLE
feat(frontend): incremental xstate (add prev/next navigation)

### DIFF
--- a/frontend/app/errors/error-codes.ts
+++ b/frontend/app/errors/error-codes.ts
@@ -12,6 +12,14 @@ export const ErrorCodes = {
   // component error codes
   MISSING_LANG_PARAM: 'CMP-0001',
 
+  // form error codes
+  UNRECOGNIZED_ACTION: 'FRM-0001',
+
+  // FSM error codes
+  MISSING_TAB_ID: 'FSM-0001',
+  MISSING_META: 'FSM-0002',
+  MISSING_SNAPSHOT: 'FSM-0003',
+
   // i18n error codes
   NO_LANGUAGE_FOUND: 'I18N-0001',
 

--- a/frontend/app/routes/protected/in-person/birth-info.tsx
+++ b/frontend/app/routes/protected/in-person/birth-info.tsx
@@ -1,21 +1,47 @@
-import { useOutletContext } from 'react-router';
+import { Form, redirect, useOutletContext } from 'react-router';
 
 import type { Route } from './+types/birth-info';
 
+import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
+import { AppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
+import { getRoute, load } from '~/routes/protected/in-person/state-machine';
 
-export function action({ context, params, request }: Route.ActionArgs) {
+export async function action({ context, params, request }: Route.ActionArgs) {
   const tabId = new URL(request.url).searchParams.get('tid');
-  if (!tabId) return null; // if no tab id, return early and wait for one
 
-  return {};
-}
+  if (!tabId) {
+    return Response.json('Tab id is required; it must not be null or empty', { status: 400 });
+  }
 
-export function loader({ context, params, request }: Route.LoaderArgs) {
-  const tabId = new URL(request.url).searchParams.get('tid');
-  if (!tabId) return null; // if no tab id, return early and wait for one
+  const actor = load(context.session, tabId);
 
-  return {};
+  const formData = await request.formData();
+  const action = formData.get('action');
+
+  switch (action) {
+    case 'prev': {
+      actor.send({ type: 'prev' });
+      break;
+    }
+
+    case 'cancel': {
+      actor.send({ type: 'cancel' });
+      break;
+    }
+
+    case 'next': {
+      actor.send({ type: 'next' });
+      break;
+    }
+
+    default: {
+      throw new AppError(`Unrecognized action: ${action}`, ErrorCodes.UNRECOGNIZED_ACTION);
+    }
+  }
+
+  throw redirect(getRoute(actor, { context, params, request }));
 }
 
 export default function BirthInfo({ actionData, loaderData, matches, params }: Route.ComponentProps) {
@@ -27,6 +53,19 @@ export default function BirthInfo({ actionData, loaderData, matches, params }: R
         <span>Birth info</span>
         <span className="block text-sm">(tabid: {tabId})</span>
       </PageTitle>
+      <Form method="post">
+        <div className="space-x-3">
+          <Button name="action" value="cancel" variant="red" size="xl">
+            Cancel
+          </Button>
+          <Button name="action" value="prev" variant="alternative" size="xl">
+            Back
+          </Button>
+          <Button name="action" value="next" variant="primary" size="xl">
+            Next
+          </Button>
+        </div>
+      </Form>
     </div>
   );
 }

--- a/frontend/app/routes/protected/in-person/contact-info.tsx
+++ b/frontend/app/routes/protected/in-person/contact-info.tsx
@@ -1,21 +1,47 @@
-import { useOutletContext } from 'react-router';
+import { Form, redirect, useOutletContext } from 'react-router';
 
 import type { Route } from './+types/contact-info';
 
+import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
+import { AppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
+import { getRoute, load } from '~/routes/protected/in-person/state-machine';
 
-export function action({ context, params, request }: Route.ActionArgs) {
+export async function action({ context, params, request }: Route.ActionArgs) {
   const tabId = new URL(request.url).searchParams.get('tid');
-  if (!tabId) return null; // if no tab id, return early and wait for one
 
-  return {};
-}
+  if (!tabId) {
+    return Response.json('Tab id is required; it must not be null or empty', { status: 400 });
+  }
 
-export function loader({ context, params, request }: Route.LoaderArgs) {
-  const tabId = new URL(request.url).searchParams.get('tid');
-  if (!tabId) return null; // if no tab id, return early and wait for one
+  const actor = load(context.session, tabId);
 
-  return {};
+  const formData = await request.formData();
+  const action = formData.get('action');
+
+  switch (action) {
+    case 'prev': {
+      actor.send({ type: 'prev' });
+      break;
+    }
+
+    case 'cancel': {
+      actor.send({ type: 'cancel' });
+      break;
+    }
+
+    case 'next': {
+      actor.send({ type: 'next' });
+      break;
+    }
+
+    default: {
+      throw new AppError(`Unrecognized action: ${action}`, ErrorCodes.UNRECOGNIZED_ACTION);
+    }
+  }
+
+  throw redirect(getRoute(actor, { context, params, request }));
 }
 
 export default function ContectInfo({ actionData, loaderData, matches, params }: Route.ComponentProps) {
@@ -27,6 +53,19 @@ export default function ContectInfo({ actionData, loaderData, matches, params }:
         <span>Contact info</span>
         <span className="block text-sm">(tabid: {tabId})</span>
       </PageTitle>
+      <Form method="post">
+        <div className="space-x-3">
+          <Button name="action" value="cancel" variant="red" size="xl">
+            Cancel
+          </Button>
+          <Button name="action" value="prev" variant="alternative" size="xl">
+            Back
+          </Button>
+          <Button name="action" value="next" variant="primary" size="xl">
+            Next
+          </Button>
+        </div>
+      </Form>{' '}
     </div>
   );
 }

--- a/frontend/app/routes/protected/in-person/index.tsx
+++ b/frontend/app/routes/protected/in-person/index.tsx
@@ -1,22 +1,37 @@
-import { Form, useOutletContext } from 'react-router';
+import { Form, redirect, useOutletContext } from 'react-router';
 
 import type { Route } from './+types/index';
 
 import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
-import { create } from '~/routes/protected/in-person/state-machine';
+import { AppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
+import { create, getRoute } from '~/routes/protected/in-person/state-machine';
 
-export function action({ context, params, request }: Route.ActionArgs) {
-  return {};
-}
-
-export function loader({ context, params, request }: Route.LoaderArgs) {
+export async function action({ context, params, request }: Route.ActionArgs) {
   const tabId = new URL(request.url).searchParams.get('tid');
-  if (!tabId) return null; // if no tab id, return early and wait for one
 
-  return {
-    actor: create(context.session, tabId).start(),
-  };
+  if (!tabId) {
+    return Response.json('Tab id is required; it must not be null or empty', { status: 400 });
+  }
+
+  const actor = create(context.session, tabId);
+
+  const formData = await request.formData();
+  const action = formData.get('action');
+
+  switch (action) {
+    case 'start': {
+      actor.send({ type: 'next' });
+      break;
+    }
+
+    default: {
+      throw new AppError(`Unrecognized action: ${action}`, ErrorCodes.UNRECOGNIZED_ACTION);
+    }
+  }
+
+  throw redirect(getRoute(actor, { context, params, request }));
 }
 
 export default function InPersonFlow({ actionData, loaderData, matches, params }: Route.ComponentProps) {
@@ -29,7 +44,7 @@ export default function InPersonFlow({ actionData, loaderData, matches, params }
         <span className="block text-sm">(tabid: {tabId})</span>
       </PageTitle>
       <Form method="post">
-        <Button variant="primary" size="xl">
+        <Button name="action" value="start" variant="primary" size="xl">
           Start
         </Button>
       </Form>

--- a/frontend/app/routes/protected/in-person/name-info.tsx
+++ b/frontend/app/routes/protected/in-person/name-info.tsx
@@ -1,21 +1,47 @@
-import { useOutletContext } from 'react-router';
+import { Form, redirect, useOutletContext } from 'react-router';
 
 import type { Route } from './+types/name-info';
 
+import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
+import { AppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
+import { getRoute, load } from '~/routes/protected/in-person/state-machine';
 
-export function action({ context, params, request }: Route.ActionArgs) {
+export async function action({ context, params, request }: Route.ActionArgs) {
   const tabId = new URL(request.url).searchParams.get('tid');
-  if (!tabId) return null; // if no tab id, return early and wait for one
 
-  return {};
-}
+  if (!tabId) {
+    return Response.json('Tab id is required; it must not be null or empty', { status: 400 });
+  }
 
-export function loader({ context, params, request }: Route.LoaderArgs) {
-  const tabId = new URL(request.url).searchParams.get('tid');
-  if (!tabId) return null; // if no tab id, return early and wait for one
+  const actor = load(context.session, tabId);
 
-  return {};
+  const formData = await request.formData();
+  const action = formData.get('action');
+
+  switch (action) {
+    case 'prev': {
+      actor.send({ type: 'prev' });
+      break;
+    }
+
+    case 'cancel': {
+      actor.send({ type: 'cancel' });
+      break;
+    }
+
+    case 'next': {
+      actor.send({ type: 'next' });
+      break;
+    }
+
+    default: {
+      throw new AppError(`Unrecognized action: ${action}`, ErrorCodes.UNRECOGNIZED_ACTION);
+    }
+  }
+
+  throw redirect(getRoute(actor, { context, params, request }));
 }
 
 export default function NameInfo({ actionData, loaderData, matches, params }: Route.ComponentProps) {
@@ -27,6 +53,19 @@ export default function NameInfo({ actionData, loaderData, matches, params }: Ro
         <span>Name info</span>
         <span className="block text-sm">(tabid: {tabId})</span>
       </PageTitle>
+      <Form method="post">
+        <div className="space-x-3">
+          <Button name="action" value="cancel" variant="red" size="xl">
+            Cancel
+          </Button>
+          <Button name="action" value="prev" variant="alternative" size="xl">
+            Back
+          </Button>
+          <Button name="action" value="next" variant="primary" size="xl">
+            Next
+          </Button>
+        </div>
+      </Form>
     </div>
   );
 }

--- a/frontend/app/routes/protected/in-person/parent-info.tsx
+++ b/frontend/app/routes/protected/in-person/parent-info.tsx
@@ -1,21 +1,47 @@
-import { useOutletContext } from 'react-router';
+import { Form, redirect, useOutletContext } from 'react-router';
 
 import type { Route } from './+types/parent-info';
 
+import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
+import { AppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
+import { getRoute, load } from '~/routes/protected/in-person/state-machine';
 
-export function action({ context, params, request }: Route.ActionArgs) {
+export async function action({ context, params, request }: Route.ActionArgs) {
   const tabId = new URL(request.url).searchParams.get('tid');
-  if (!tabId) return null; // if no tab id, return early and wait for one
 
-  return {};
-}
+  if (!tabId) {
+    return Response.json('Tab id is required; it must not be null or empty', { status: 400 });
+  }
 
-export function loader({ context, params, request }: Route.LoaderArgs) {
-  const tabId = new URL(request.url).searchParams.get('tid');
-  if (!tabId) return null; // if no tab id, return early and wait for one
+  const actor = load(context.session, tabId);
 
-  return {};
+  const formData = await request.formData();
+  const action = formData.get('action');
+
+  switch (action) {
+    case 'prev': {
+      actor.send({ type: 'prev' });
+      break;
+    }
+
+    case 'cancel': {
+      actor.send({ type: 'cancel' });
+      break;
+    }
+
+    case 'next': {
+      actor.send({ type: 'next' });
+      break;
+    }
+
+    default: {
+      throw new AppError(`Unrecognized action: ${action}`, ErrorCodes.UNRECOGNIZED_ACTION);
+    }
+  }
+
+  throw redirect(getRoute(actor, { context, params, request }));
 }
 
 export default function ParentInfo({ actionData, loaderData, matches, params }: Route.ComponentProps) {
@@ -27,6 +53,19 @@ export default function ParentInfo({ actionData, loaderData, matches, params }: 
         <span>Parent info</span>
         <span className="block text-sm">(tabid: {tabId})</span>
       </PageTitle>
+      <Form method="post">
+        <div className="space-x-3">
+          <Button name="action" value="cancel" variant="red" size="xl">
+            Cancel
+          </Button>
+          <Button name="action" value="prev" variant="alternative" size="xl">
+            Back
+          </Button>
+          <Button name="action" value="next" variant="primary" size="xl">
+            Next
+          </Button>
+        </div>
+      </Form>{' '}
     </div>
   );
 }

--- a/frontend/app/routes/protected/in-person/personal-info.tsx
+++ b/frontend/app/routes/protected/in-person/personal-info.tsx
@@ -1,21 +1,47 @@
-import { useOutletContext } from 'react-router';
+import { Form, redirect, useOutletContext } from 'react-router';
 
 import type { Route } from './+types/personal-info';
 
+import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
+import { AppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
+import { getRoute, load } from '~/routes/protected/in-person/state-machine';
 
-export function action({ context, params, request }: Route.ActionArgs) {
+export async function action({ context, params, request }: Route.ActionArgs) {
   const tabId = new URL(request.url).searchParams.get('tid');
-  if (!tabId) return null; // if no tab id, return early and wait for one
 
-  return {};
-}
+  if (!tabId) {
+    return Response.json('Tab id is required; it must not be null or empty', { status: 400 });
+  }
 
-export function loader({ context, params, request }: Route.LoaderArgs) {
-  const tabId = new URL(request.url).searchParams.get('tid');
-  if (!tabId) return null; // if no tab id, return early and wait for one
+  const actor = load(context.session, tabId);
 
-  return {};
+  const formData = await request.formData();
+  const action = formData.get('action');
+
+  switch (action) {
+    case 'prev': {
+      actor.send({ type: 'prev' });
+      break;
+    }
+
+    case 'cancel': {
+      actor.send({ type: 'cancel' });
+      break;
+    }
+
+    case 'next': {
+      actor.send({ type: 'next' });
+      break;
+    }
+
+    default: {
+      throw new AppError(`Unrecognized action: ${action}`, ErrorCodes.UNRECOGNIZED_ACTION);
+    }
+  }
+
+  throw redirect(getRoute(actor, { context, params, request }));
 }
 
 export default function PersonalInfo({ actionData, loaderData, matches, params }: Route.ComponentProps) {
@@ -27,6 +53,19 @@ export default function PersonalInfo({ actionData, loaderData, matches, params }
         <span>Personal info</span>
         <span className="block text-sm">(tabid: {tabId})</span>
       </PageTitle>
+      <Form method="post">
+        <div className="space-x-3">
+          <Button name="action" value="cancel" variant="red" size="xl">
+            Cancel
+          </Button>
+          <Button name="action" value="prev" variant="alternative" size="xl">
+            Back
+          </Button>
+          <Button name="action" value="next" variant="primary" size="xl">
+            Next
+          </Button>
+        </div>
+      </Form>
     </div>
   );
 }

--- a/frontend/app/routes/protected/in-person/previous-sin-info.tsx
+++ b/frontend/app/routes/protected/in-person/previous-sin-info.tsx
@@ -1,21 +1,47 @@
-import { useOutletContext } from 'react-router';
+import { Form, redirect, useOutletContext } from 'react-router';
 
 import type { Route } from './+types/previous-sin-info';
 
+import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
+import { AppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
+import { getRoute, load } from '~/routes/protected/in-person/state-machine';
 
-export function action({ context, params, request }: Route.ActionArgs) {
+export async function action({ context, params, request }: Route.ActionArgs) {
   const tabId = new URL(request.url).searchParams.get('tid');
-  if (!tabId) return null; // if no tab id, return early and wait for one
 
-  return {};
-}
+  if (!tabId) {
+    return Response.json('Tab id is required; it must not be null or empty', { status: 400 });
+  }
 
-export function loader({ context, params, request }: Route.LoaderArgs) {
-  const tabId = new URL(request.url).searchParams.get('tid');
-  if (!tabId) return null; // if no tab id, return early and wait for one
+  const actor = load(context.session, tabId);
 
-  return {};
+  const formData = await request.formData();
+  const action = formData.get('action');
+
+  switch (action) {
+    case 'prev': {
+      actor.send({ type: 'prev' });
+      break;
+    }
+
+    case 'cancel': {
+      actor.send({ type: 'cancel' });
+      break;
+    }
+
+    case 'next': {
+      actor.send({ type: 'next' });
+      break;
+    }
+
+    default: {
+      throw new AppError(`Unrecognized action: ${action}`, ErrorCodes.UNRECOGNIZED_ACTION);
+    }
+  }
+
+  throw redirect(getRoute(actor, { context, params, request }));
 }
 
 export default function PreviousSinInfo({ actionData, loaderData, matches, params }: Route.ComponentProps) {
@@ -27,6 +53,19 @@ export default function PreviousSinInfo({ actionData, loaderData, matches, param
         <span>Previous SIN info</span>
         <span className="block text-sm">(tabid: {tabId})</span>
       </PageTitle>
+      <Form method="post">
+        <div className="space-x-3">
+          <Button name="action" value="cancel" variant="red" size="xl">
+            Cancel
+          </Button>
+          <Button name="action" value="prev" variant="alternative" size="xl">
+            Back
+          </Button>
+          <Button name="action" value="next" variant="primary" size="xl">
+            Next
+          </Button>
+        </div>
+      </Form>{' '}
     </div>
   );
 }

--- a/frontend/app/routes/protected/in-person/primary-docs.tsx
+++ b/frontend/app/routes/protected/in-person/primary-docs.tsx
@@ -1,21 +1,47 @@
-import { useOutletContext } from 'react-router';
+import { Form, redirect, useOutletContext } from 'react-router';
 
 import type { Route } from './+types/primary-docs';
 
+import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
+import { AppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
+import { getRoute, load } from '~/routes/protected/in-person/state-machine';
 
-export function action({ context, params, request }: Route.ActionArgs) {
+export async function action({ context, params, request }: Route.ActionArgs) {
   const tabId = new URL(request.url).searchParams.get('tid');
-  if (!tabId) return null; // if no tab id, return early and wait for one
 
-  return {};
-}
+  if (!tabId) {
+    return Response.json('Tab id is required; it must not be null or empty', { status: 400 });
+  }
 
-export function loader({ context, params, request }: Route.LoaderArgs) {
-  const tabId = new URL(request.url).searchParams.get('tid');
-  if (!tabId) return null; // if no tab id, return early and wait for one
+  const actor = load(context.session, tabId);
 
-  return {};
+  const formData = await request.formData();
+  const action = formData.get('action');
+
+  switch (action) {
+    case 'prev': {
+      actor.send({ type: 'prev' });
+      break;
+    }
+
+    case 'cancel': {
+      actor.send({ type: 'cancel' });
+      break;
+    }
+
+    case 'next': {
+      actor.send({ type: 'next' });
+      break;
+    }
+
+    default: {
+      throw new AppError(`Unrecognized action: ${action}`, ErrorCodes.UNRECOGNIZED_ACTION);
+    }
+  }
+
+  throw redirect(getRoute(actor, { context, params, request }));
 }
 
 export default function PrimaryDocs({ actionData, loaderData, matches, params }: Route.ComponentProps) {
@@ -27,6 +53,19 @@ export default function PrimaryDocs({ actionData, loaderData, matches, params }:
         <span>Primary docs</span>
         <span className="block text-sm">(tabid: {tabId})</span>
       </PageTitle>
+      <Form method="post">
+        <div className="space-x-3">
+          <Button name="action" value="cancel" variant="red" size="xl">
+            Cancel
+          </Button>
+          <Button name="action" value="prev" variant="alternative" size="xl">
+            Back
+          </Button>
+          <Button name="action" value="next" variant="primary" size="xl">
+            Next
+          </Button>
+        </div>
+      </Form>
     </div>
   );
 }

--- a/frontend/app/routes/protected/in-person/privacy-statement.tsx
+++ b/frontend/app/routes/protected/in-person/privacy-statement.tsx
@@ -1,21 +1,42 @@
-import { useOutletContext } from 'react-router';
+import { Form, redirect, useOutletContext } from 'react-router';
 
 import type { Route } from './+types/privacy-statement';
 
+import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
+import { AppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
+import { getRoute, load } from '~/routes/protected/in-person/state-machine';
 
-export function action({ context, params, request }: Route.ActionArgs) {
+export async function action({ context, params, request }: Route.ActionArgs) {
   const tabId = new URL(request.url).searchParams.get('tid');
-  if (!tabId) return null; // if no tab id, return early and wait for one
 
-  return {};
-}
+  if (!tabId) {
+    return Response.json('Tab id is required; it must not be null or empty', { status: 400 });
+  }
 
-export function loader({ context, params, request }: Route.LoaderArgs) {
-  const tabId = new URL(request.url).searchParams.get('tid');
-  if (!tabId) return null; // if no tab id, return early and wait for one
+  const actor = load(context.session, tabId);
 
-  return {};
+  const formData = await request.formData();
+  const action = formData.get('action');
+
+  switch (action) {
+    case 'cancel': {
+      actor.send({ type: 'cancel' });
+      break;
+    }
+
+    case 'next': {
+      actor.send({ type: 'next' });
+      break;
+    }
+
+    default: {
+      throw new AppError(`Unrecognized action: ${action}`, ErrorCodes.UNRECOGNIZED_ACTION);
+    }
+  }
+
+  throw redirect(getRoute(actor, { context, params, request }));
 }
 
 export default function PrivacyStatement({ actionData, loaderData, matches, params }: Route.ComponentProps) {
@@ -27,6 +48,16 @@ export default function PrivacyStatement({ actionData, loaderData, matches, para
         <span>Privacy statement</span>
         <span className="block text-sm">(tabid: {tabId})</span>
       </PageTitle>
+      <Form method="post">
+        <div className="space-x-3">
+          <Button name="action" value="cancel" variant="red" size="xl">
+            Cancel
+          </Button>
+          <Button name="action" value="next" variant="primary" size="xl">
+            Next
+          </Button>
+        </div>
+      </Form>
     </div>
   );
 }

--- a/frontend/app/routes/protected/in-person/request-details.tsx
+++ b/frontend/app/routes/protected/in-person/request-details.tsx
@@ -1,21 +1,47 @@
-import { useOutletContext } from 'react-router';
+import { Form, redirect, useOutletContext } from 'react-router';
 
 import type { Route } from './+types/request-details';
 
+import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
+import { AppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
+import { getRoute, load } from '~/routes/protected/in-person/state-machine';
 
-export function action({ context, params, request }: Route.ActionArgs) {
+export async function action({ context, params, request }: Route.ActionArgs) {
   const tabId = new URL(request.url).searchParams.get('tid');
-  if (!tabId) return null; // if no tab id, return early and wait for one
 
-  return {};
-}
+  if (!tabId) {
+    return Response.json('Tab id is required; it must not be null or empty', { status: 400 });
+  }
 
-export function loader({ context, params, request }: Route.LoaderArgs) {
-  const tabId = new URL(request.url).searchParams.get('tid');
-  if (!tabId) return null; // if no tab id, return early and wait for one
+  const actor = load(context.session, tabId);
 
-  return {};
+  const formData = await request.formData();
+  const action = formData.get('action');
+
+  switch (action) {
+    case 'prev': {
+      actor.send({ type: 'prev' });
+      break;
+    }
+
+    case 'cancel': {
+      actor.send({ type: 'cancel' });
+      break;
+    }
+
+    case 'next': {
+      actor.send({ type: 'next' });
+      break;
+    }
+
+    default: {
+      throw new AppError(`Unrecognized action: ${action}`, ErrorCodes.UNRECOGNIZED_ACTION);
+    }
+  }
+
+  throw redirect(getRoute(actor, { context, params, request }));
 }
 
 export default function RequestDetails({ actionData, loaderData, matches, params }: Route.ComponentProps) {
@@ -27,6 +53,19 @@ export default function RequestDetails({ actionData, loaderData, matches, params
         <span>Request details</span>
         <span className="block text-sm">(tabid: {tabId})</span>
       </PageTitle>
+      <Form method="post">
+        <div className="space-x-3">
+          <Button name="action" value="cancel" variant="red" size="xl">
+            Cancel
+          </Button>
+          <Button name="action" value="prev" variant="alternative" size="xl">
+            Back
+          </Button>
+          <Button name="action" value="next" variant="primary" size="xl">
+            Next
+          </Button>
+        </div>
+      </Form>
     </div>
   );
 }

--- a/frontend/app/routes/protected/in-person/review.tsx
+++ b/frontend/app/routes/protected/in-person/review.tsx
@@ -1,21 +1,42 @@
-import { useOutletContext } from 'react-router';
+import { Form, redirect, useOutletContext } from 'react-router';
 
 import type { Route } from './+types/review';
 
+import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
+import { AppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
+import { getRoute, load } from '~/routes/protected/in-person/state-machine';
 
-export function action({ context, params, request }: Route.ActionArgs) {
+export async function action({ context, params, request }: Route.ActionArgs) {
   const tabId = new URL(request.url).searchParams.get('tid');
-  if (!tabId) return null; // if no tab id, return early and wait for one
 
-  return {};
-}
+  if (!tabId) {
+    return Response.json('Tab id is required; it must not be null or empty', { status: 400 });
+  }
 
-export function loader({ context, params, request }: Route.LoaderArgs) {
-  const tabId = new URL(request.url).searchParams.get('tid');
-  if (!tabId) return null; // if no tab id, return early and wait for one
+  const actor = load(context.session, tabId);
 
-  return {};
+  const formData = await request.formData();
+  const action = formData.get('action');
+
+  switch (action) {
+    case 'cancel': {
+      actor.send({ type: 'cancel' });
+      break;
+    }
+
+    case 'next': {
+      actor.send({ type: 'next' });
+      break;
+    }
+
+    default: {
+      throw new AppError(`Unrecognized action: ${action}`, ErrorCodes.UNRECOGNIZED_ACTION);
+    }
+  }
+
+  throw redirect(getRoute(actor, { context, params, request }));
 }
 
 export default function Review({ actionData, loaderData, matches, params }: Route.ComponentProps) {
@@ -27,6 +48,16 @@ export default function Review({ actionData, loaderData, matches, params }: Rout
         <span>Review</span>
         <span className="block text-sm">(tabid: {tabId})</span>
       </PageTitle>
+      <Form method="post">
+        <div className="space-x-3">
+          <Button name="action" value="cancel" variant="red" size="xl">
+            Cancel
+          </Button>
+          <Button name="action" value="next" variant="primary" size="xl">
+            Submit
+          </Button>
+        </div>
+      </Form>
     </div>
   );
 }

--- a/frontend/app/routes/protected/in-person/secondary-docs.tsx
+++ b/frontend/app/routes/protected/in-person/secondary-docs.tsx
@@ -1,21 +1,47 @@
-import { useOutletContext } from 'react-router';
+import { Form, redirect, useOutletContext } from 'react-router';
 
 import type { Route } from './+types/secondary-docs';
 
+import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
+import { AppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
+import { getRoute, load } from '~/routes/protected/in-person/state-machine';
 
-export function action({ context, params, request }: Route.ActionArgs) {
+export async function action({ context, params, request }: Route.ActionArgs) {
   const tabId = new URL(request.url).searchParams.get('tid');
-  if (!tabId) return null; // if no tab id, return early and wait for one
 
-  return {};
-}
+  if (!tabId) {
+    return Response.json('Tab id is required; it must not be null or empty', { status: 400 });
+  }
 
-export function loader({ context, params, request }: Route.LoaderArgs) {
-  const tabId = new URL(request.url).searchParams.get('tid');
-  if (!tabId) return null; // if no tab id, return early and wait for one
+  const actor = load(context.session, tabId);
 
-  return {};
+  const formData = await request.formData();
+  const action = formData.get('action');
+
+  switch (action) {
+    case 'prev': {
+      actor.send({ type: 'prev' });
+      break;
+    }
+
+    case 'cancel': {
+      actor.send({ type: 'cancel' });
+      break;
+    }
+
+    case 'next': {
+      actor.send({ type: 'next' });
+      break;
+    }
+
+    default: {
+      throw new AppError(`Unrecognized action: ${action}`, ErrorCodes.UNRECOGNIZED_ACTION);
+    }
+  }
+
+  throw redirect(getRoute(actor, { context, params, request }));
 }
 
 export default function SecondayDocs({ actionData, loaderData, matches, params }: Route.ComponentProps) {
@@ -27,6 +53,19 @@ export default function SecondayDocs({ actionData, loaderData, matches, params }
         <span>Secondary docs</span>
         <span className="block text-sm">(tabid: {tabId})</span>
       </PageTitle>
+      <Form method="post">
+        <div className="space-x-3">
+          <Button name="action" value="cancel" variant="red" size="xl">
+            Cancel
+          </Button>
+          <Button name="action" value="prev" variant="alternative" size="xl">
+            Back
+          </Button>
+          <Button name="action" value="next" variant="primary" size="xl">
+            Next
+          </Button>
+        </div>
+      </Form>{' '}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Incremental update to XState FSM implementation. This PR adds prev/next/cancel navigation to the routes. Form data is not stored, and no validation is done in the actions. This PR simply adds some rudimentary navigation so that future PRs will be smaller.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>
