### PR TITLE
refactor(frontend): privacy statement data storage and validation

### DIFF
--- a/frontend/app/.server/locales/protected-en.json
+++ b/frontend/app/.server/locales/protected-en.json
@@ -37,7 +37,7 @@
   "privacy-statement": {
     "confirm-privacy-notice-checkbox": {
       "title": "I agree to the terms and conditions",
-      "required": "Privacy notice statement is required."
+      "required": "Agreeing to the terms and conditions is required."
     },
     "page-title": "Privacy Statement"
   },

--- a/frontend/app/.server/locales/protected-fr.json
+++ b/frontend/app/.server/locales/protected-fr.json
@@ -37,7 +37,7 @@
   "privacy-statement": {
     "confirm-privacy-notice-checkbox": {
       "title": "J'accepte les termes et conditions.",
-      "required": "Privacy notice statement is required."
+      "required": "L'acceptation des termes et conditions est obligatoire."
     },
     "page-title": "Déclaration de confidentialité"
   },

--- a/frontend/app/@types/express-session.d.ts
+++ b/frontend/app/@types/express-session.d.ts
@@ -16,12 +16,20 @@ declare module 'express-session' {
       state: string;
     };
     /**
-     * Stores data for an in-person SIN case
+     * Represents the session data for the in-person SIN case.
      */
     inPersonSINCase: {
       firstName?: string;
       lastName?: string;
-      confirmPrivacyNotice?: string;
+      /**
+       * Represents the privacy statement data for the in-person SIN case.
+       */
+      privacyStatement?: {
+        /**
+         * Indicates whether the user has agreed to the terms of the privacy statement.
+         */
+        agreedToTerms: true;
+      };
       currentStatusInCanada?: string;
     };
   }


### PR DESCRIPTION
## Summary

- Updates session data by changing `confirmPrivacyNotice` to a `privacyStatement` object for storing route data.
- Implements valibot's `v.GenericSchema` to enforce schema and input types.
- Modifies the `required` error message in both languages.

[AB#16376](https://dev.azure.com/ESDCCM/a4b4f7af-bbd7-4f0d-83ab-a123d0b70fda/_workitems/edit/16376)

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [x] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
