### PR TITLE
fix(frontend): improve xstate navigation

### DIFF
--- a/frontend/app/errors/error-codes.ts
+++ b/frontend/app/errors/error-codes.ts
@@ -15,11 +15,6 @@ export const ErrorCodes = {
   // form error codes
   UNRECOGNIZED_ACTION: 'FRM-0001',
 
-  // FSM error codes
-  MISSING_TAB_ID: 'FSM-0001',
-  MISSING_META: 'FSM-0002',
-  MISSING_SNAPSHOT: 'FSM-0003',
-
   // i18n error codes
   NO_LANGUAGE_FOUND: 'I18N-0001',
 

--- a/frontend/app/routes/protected/in-person/birth-info.tsx
+++ b/frontend/app/routes/protected/in-person/birth-info.tsx
@@ -1,4 +1,4 @@
-import { Form, redirect, useOutletContext } from 'react-router';
+import { Form, redirect } from 'react-router';
 
 import type { Route } from './+types/birth-info';
 
@@ -6,16 +6,10 @@ import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
-import { getRoute, load } from '~/routes/protected/in-person/state-machine';
+import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service';
 
 export async function action({ context, params, request }: Route.ActionArgs) {
-  const tabId = new URL(request.url).searchParams.get('tid');
-
-  if (!tabId) {
-    return Response.json('Tab id is required; it must not be null or empty', { status: 400 });
-  }
-
-  const actor = load(context.session, tabId);
+  const actor = loadMachineActor(context.session, request, 'birth-info');
 
   const formData = await request.formData();
   const action = formData.get('action');
@@ -41,17 +35,20 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     }
   }
 
-  throw redirect(getRoute(actor, { context, params, request }));
+  throw redirect(getStateRoute(actor, { context, params, request }));
+}
+
+export function loader({ context, params, request }: Route.LoaderArgs) {
+  loadMachineActor(context.session, request, 'birth-info');
+  return { tabId: new URL(request.url).searchParams.get('tid') };
 }
 
 export default function BirthInfo({ actionData, loaderData, matches, params }: Route.ComponentProps) {
-  const { tabId } = useOutletContext<{ tabId: string }>();
-
   return (
     <div className="space-y-3">
       <PageTitle>
         <span>Birth info</span>
-        <span className="block text-sm">(tabid: {tabId})</span>
+        <span className="block text-sm">(tabid: {loaderData.tabId})</span>
       </PageTitle>
       <Form method="post">
         <div className="space-x-3">

--- a/frontend/app/routes/protected/in-person/birth-info.tsx
+++ b/frontend/app/routes/protected/in-person/birth-info.tsx
@@ -6,7 +6,7 @@ import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
-import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service';
+import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service.server';
 
 export async function action({ context, params, request }: Route.ActionArgs) {
   const actor = loadMachineActor(context.session, request, 'birth-info');

--- a/frontend/app/routes/protected/in-person/contact-info.tsx
+++ b/frontend/app/routes/protected/in-person/contact-info.tsx
@@ -6,7 +6,7 @@ import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
-import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service';
+import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service.server';
 
 export async function action({ context, params, request }: Route.ActionArgs) {
   const actor = loadMachineActor(context.session, request, 'contact-info');

--- a/frontend/app/routes/protected/in-person/contact-info.tsx
+++ b/frontend/app/routes/protected/in-person/contact-info.tsx
@@ -1,4 +1,4 @@
-import { Form, redirect, useOutletContext } from 'react-router';
+import { Form, redirect } from 'react-router';
 
 import type { Route } from './+types/contact-info';
 
@@ -6,16 +6,10 @@ import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
-import { getRoute, load } from '~/routes/protected/in-person/state-machine';
+import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service';
 
 export async function action({ context, params, request }: Route.ActionArgs) {
-  const tabId = new URL(request.url).searchParams.get('tid');
-
-  if (!tabId) {
-    return Response.json('Tab id is required; it must not be null or empty', { status: 400 });
-  }
-
-  const actor = load(context.session, tabId);
+  const actor = loadMachineActor(context.session, request, 'contact-info');
 
   const formData = await request.formData();
   const action = formData.get('action');
@@ -41,17 +35,20 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     }
   }
 
-  throw redirect(getRoute(actor, { context, params, request }));
+  throw redirect(getStateRoute(actor, { context, params, request }));
 }
 
-export default function ContectInfo({ actionData, loaderData, matches, params }: Route.ComponentProps) {
-  const { tabId } = useOutletContext<{ tabId: string }>();
+export function loader({ context, params, request }: Route.LoaderArgs) {
+  loadMachineActor(context.session, request, 'contact-info');
+  return { tabId: new URL(request.url).searchParams.get('tid') };
+}
 
+export default function ContactInfo({ actionData, loaderData, matches, params }: Route.ComponentProps) {
   return (
     <div className="space-y-3">
       <PageTitle>
         <span>Contact info</span>
-        <span className="block text-sm">(tabid: {tabId})</span>
+        <span className="block text-sm">(tabid: {loaderData.tabId})</span>
       </PageTitle>
       <Form method="post">
         <div className="space-x-3">

--- a/frontend/app/routes/protected/in-person/index.tsx
+++ b/frontend/app/routes/protected/in-person/index.tsx
@@ -6,7 +6,7 @@ import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
-import { createMachineActor, getStateRoute } from '~/routes/protected/in-person/state-machine-service';
+import { createMachineActor, getStateRoute } from '~/routes/protected/in-person/state-machine-service.server';
 
 export async function action({ context, params, request }: Route.ActionArgs) {
   const actor = createMachineActor(context.session, request);

--- a/frontend/app/routes/protected/in-person/name-info.tsx
+++ b/frontend/app/routes/protected/in-person/name-info.tsx
@@ -1,4 +1,4 @@
-import { Form, redirect, useOutletContext } from 'react-router';
+import { Form, redirect } from 'react-router';
 
 import type { Route } from './+types/name-info';
 
@@ -6,16 +6,10 @@ import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
-import { getRoute, load } from '~/routes/protected/in-person/state-machine';
+import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service';
 
 export async function action({ context, params, request }: Route.ActionArgs) {
-  const tabId = new URL(request.url).searchParams.get('tid');
-
-  if (!tabId) {
-    return Response.json('Tab id is required; it must not be null or empty', { status: 400 });
-  }
-
-  const actor = load(context.session, tabId);
+  const actor = loadMachineActor(context.session, request, 'name-info');
 
   const formData = await request.formData();
   const action = formData.get('action');
@@ -41,17 +35,20 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     }
   }
 
-  throw redirect(getRoute(actor, { context, params, request }));
+  throw redirect(getStateRoute(actor, { context, params, request }));
+}
+
+export function loader({ context, params, request }: Route.LoaderArgs) {
+  loadMachineActor(context.session, request, 'name-info');
+  return { tabId: new URL(request.url).searchParams.get('tid') };
 }
 
 export default function NameInfo({ actionData, loaderData, matches, params }: Route.ComponentProps) {
-  const { tabId } = useOutletContext<{ tabId: string }>();
-
   return (
     <div className="space-y-3">
       <PageTitle>
         <span>Name info</span>
-        <span className="block text-sm">(tabid: {tabId})</span>
+        <span className="block text-sm">(tabid: {loaderData.tabId})</span>
       </PageTitle>
       <Form method="post">
         <div className="space-x-3">

--- a/frontend/app/routes/protected/in-person/name-info.tsx
+++ b/frontend/app/routes/protected/in-person/name-info.tsx
@@ -6,7 +6,7 @@ import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
-import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service';
+import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service.server';
 
 export async function action({ context, params, request }: Route.ActionArgs) {
   const actor = loadMachineActor(context.session, request, 'name-info');

--- a/frontend/app/routes/protected/in-person/parent-info.tsx
+++ b/frontend/app/routes/protected/in-person/parent-info.tsx
@@ -6,7 +6,7 @@ import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
-import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service';
+import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service.server';
 
 export async function action({ context, params, request }: Route.ActionArgs) {
   const actor = loadMachineActor(context.session, request, 'parent-info');

--- a/frontend/app/routes/protected/in-person/parent-info.tsx
+++ b/frontend/app/routes/protected/in-person/parent-info.tsx
@@ -1,4 +1,4 @@
-import { Form, redirect, useOutletContext } from 'react-router';
+import { Form, redirect } from 'react-router';
 
 import type { Route } from './+types/parent-info';
 
@@ -6,16 +6,10 @@ import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
-import { getRoute, load } from '~/routes/protected/in-person/state-machine';
+import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service';
 
 export async function action({ context, params, request }: Route.ActionArgs) {
-  const tabId = new URL(request.url).searchParams.get('tid');
-
-  if (!tabId) {
-    return Response.json('Tab id is required; it must not be null or empty', { status: 400 });
-  }
-
-  const actor = load(context.session, tabId);
+  const actor = loadMachineActor(context.session, request, 'parent-info');
 
   const formData = await request.formData();
   const action = formData.get('action');
@@ -41,17 +35,20 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     }
   }
 
-  throw redirect(getRoute(actor, { context, params, request }));
+  throw redirect(getStateRoute(actor, { context, params, request }));
+}
+
+export function loader({ context, params, request }: Route.LoaderArgs) {
+  loadMachineActor(context.session, request, 'parent-info');
+  return { tabId: new URL(request.url).searchParams.get('tid') };
 }
 
 export default function ParentInfo({ actionData, loaderData, matches, params }: Route.ComponentProps) {
-  const { tabId } = useOutletContext<{ tabId: string }>();
-
   return (
     <div className="space-y-3">
       <PageTitle>
         <span>Parent info</span>
-        <span className="block text-sm">(tabid: {tabId})</span>
+        <span className="block text-sm">(tabid: {loaderData.tabId})</span>
       </PageTitle>
       <Form method="post">
         <div className="space-x-3">

--- a/frontend/app/routes/protected/in-person/personal-info.tsx
+++ b/frontend/app/routes/protected/in-person/personal-info.tsx
@@ -1,4 +1,4 @@
-import { Form, redirect, useOutletContext } from 'react-router';
+import { Form, redirect } from 'react-router';
 
 import type { Route } from './+types/personal-info';
 
@@ -6,16 +6,10 @@ import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
-import { getRoute, load } from '~/routes/protected/in-person/state-machine';
+import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service';
 
 export async function action({ context, params, request }: Route.ActionArgs) {
-  const tabId = new URL(request.url).searchParams.get('tid');
-
-  if (!tabId) {
-    return Response.json('Tab id is required; it must not be null or empty', { status: 400 });
-  }
-
-  const actor = load(context.session, tabId);
+  const actor = loadMachineActor(context.session, request, 'personal-info');
 
   const formData = await request.formData();
   const action = formData.get('action');
@@ -41,17 +35,20 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     }
   }
 
-  throw redirect(getRoute(actor, { context, params, request }));
+  throw redirect(getStateRoute(actor, { context, params, request }));
+}
+
+export function loader({ context, params, request }: Route.LoaderArgs) {
+  loadMachineActor(context.session, request, 'personal-info');
+  return { tabId: new URL(request.url).searchParams.get('tid') };
 }
 
 export default function PersonalInfo({ actionData, loaderData, matches, params }: Route.ComponentProps) {
-  const { tabId } = useOutletContext<{ tabId: string }>();
-
   return (
     <div className="space-y-3">
       <PageTitle>
         <span>Personal info</span>
-        <span className="block text-sm">(tabid: {tabId})</span>
+        <span className="block text-sm">(tabid: {loaderData.tabId})</span>
       </PageTitle>
       <Form method="post">
         <div className="space-x-3">

--- a/frontend/app/routes/protected/in-person/personal-info.tsx
+++ b/frontend/app/routes/protected/in-person/personal-info.tsx
@@ -6,7 +6,7 @@ import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
-import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service';
+import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service.server';
 
 export async function action({ context, params, request }: Route.ActionArgs) {
   const actor = loadMachineActor(context.session, request, 'personal-info');

--- a/frontend/app/routes/protected/in-person/previous-sin-info.tsx
+++ b/frontend/app/routes/protected/in-person/previous-sin-info.tsx
@@ -1,4 +1,4 @@
-import { Form, redirect, useOutletContext } from 'react-router';
+import { Form, redirect } from 'react-router';
 
 import type { Route } from './+types/previous-sin-info';
 
@@ -6,16 +6,10 @@ import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
-import { getRoute, load } from '~/routes/protected/in-person/state-machine';
+import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service';
 
 export async function action({ context, params, request }: Route.ActionArgs) {
-  const tabId = new URL(request.url).searchParams.get('tid');
-
-  if (!tabId) {
-    return Response.json('Tab id is required; it must not be null or empty', { status: 400 });
-  }
-
-  const actor = load(context.session, tabId);
+  const actor = loadMachineActor(context.session, request, 'previous-sin-info');
 
   const formData = await request.formData();
   const action = formData.get('action');
@@ -41,17 +35,20 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     }
   }
 
-  throw redirect(getRoute(actor, { context, params, request }));
+  throw redirect(getStateRoute(actor, { context, params, request }));
+}
+
+export function loader({ context, params, request }: Route.LoaderArgs) {
+  loadMachineActor(context.session, request, 'previous-sin-info');
+  return { tabId: new URL(request.url).searchParams.get('tid') };
 }
 
 export default function PreviousSinInfo({ actionData, loaderData, matches, params }: Route.ComponentProps) {
-  const { tabId } = useOutletContext<{ tabId: string }>();
-
   return (
     <div className="space-y-3">
       <PageTitle>
         <span>Previous SIN info</span>
-        <span className="block text-sm">(tabid: {tabId})</span>
+        <span className="block text-sm">(tabid: {loaderData.tabId})</span>
       </PageTitle>
       <Form method="post">
         <div className="space-x-3">

--- a/frontend/app/routes/protected/in-person/previous-sin-info.tsx
+++ b/frontend/app/routes/protected/in-person/previous-sin-info.tsx
@@ -6,7 +6,7 @@ import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
-import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service';
+import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service.server';
 
 export async function action({ context, params, request }: Route.ActionArgs) {
   const actor = loadMachineActor(context.session, request, 'previous-sin-info');

--- a/frontend/app/routes/protected/in-person/primary-docs.tsx
+++ b/frontend/app/routes/protected/in-person/primary-docs.tsx
@@ -1,4 +1,4 @@
-import { Form, redirect, useOutletContext } from 'react-router';
+import { Form, redirect } from 'react-router';
 
 import type { Route } from './+types/primary-docs';
 
@@ -6,16 +6,10 @@ import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
-import { getRoute, load } from '~/routes/protected/in-person/state-machine';
+import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service';
 
 export async function action({ context, params, request }: Route.ActionArgs) {
-  const tabId = new URL(request.url).searchParams.get('tid');
-
-  if (!tabId) {
-    return Response.json('Tab id is required; it must not be null or empty', { status: 400 });
-  }
-
-  const actor = load(context.session, tabId);
+  const actor = loadMachineActor(context.session, request, 'primary-docs');
 
   const formData = await request.formData();
   const action = formData.get('action');
@@ -41,17 +35,20 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     }
   }
 
-  throw redirect(getRoute(actor, { context, params, request }));
+  throw redirect(getStateRoute(actor, { context, params, request }));
+}
+
+export function loader({ context, params, request }: Route.LoaderArgs) {
+  loadMachineActor(context.session, request, 'primary-docs');
+  return { tabId: new URL(request.url).searchParams.get('tid') };
 }
 
 export default function PrimaryDocs({ actionData, loaderData, matches, params }: Route.ComponentProps) {
-  const { tabId } = useOutletContext<{ tabId: string }>();
-
   return (
     <div className="space-y-3">
       <PageTitle>
         <span>Primary docs</span>
-        <span className="block text-sm">(tabid: {tabId})</span>
+        <span className="block text-sm">(tabid: {loaderData.tabId})</span>
       </PageTitle>
       <Form method="post">
         <div className="space-x-3">

--- a/frontend/app/routes/protected/in-person/primary-docs.tsx
+++ b/frontend/app/routes/protected/in-person/primary-docs.tsx
@@ -6,7 +6,7 @@ import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
-import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service';
+import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service.server';
 
 export async function action({ context, params, request }: Route.ActionArgs) {
   const actor = loadMachineActor(context.session, request, 'primary-docs');

--- a/frontend/app/routes/protected/in-person/privacy-statement.tsx
+++ b/frontend/app/routes/protected/in-person/privacy-statement.tsx
@@ -1,4 +1,4 @@
-import { Form, redirect, useOutletContext } from 'react-router';
+import { Form, redirect } from 'react-router';
 
 import type { Route } from './+types/privacy-statement';
 
@@ -6,16 +6,10 @@ import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
-import { getRoute, load } from '~/routes/protected/in-person/state-machine';
+import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service';
 
 export async function action({ context, params, request }: Route.ActionArgs) {
-  const tabId = new URL(request.url).searchParams.get('tid');
-
-  if (!tabId) {
-    return Response.json('Tab id is required; it must not be null or empty', { status: 400 });
-  }
-
-  const actor = load(context.session, tabId);
+  const actor = loadMachineActor(context.session, request, 'privacy-statement');
 
   const formData = await request.formData();
   const action = formData.get('action');
@@ -36,17 +30,20 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     }
   }
 
-  throw redirect(getRoute(actor, { context, params, request }));
+  throw redirect(getStateRoute(actor, { context, params, request }));
+}
+
+export function loader({ context, params, request }: Route.LoaderArgs) {
+  loadMachineActor(context.session, request, 'privacy-statement');
+  return { tabId: new URL(request.url).searchParams.get('tid') };
 }
 
 export default function PrivacyStatement({ actionData, loaderData, matches, params }: Route.ComponentProps) {
-  const { tabId } = useOutletContext<{ tabId: string }>();
-
   return (
     <div className="space-y-3">
       <PageTitle>
         <span>Privacy statement</span>
-        <span className="block text-sm">(tabid: {tabId})</span>
+        <span className="block text-sm">(tabid: {loaderData.tabId})</span>
       </PageTitle>
       <Form method="post">
         <div className="space-x-3">

--- a/frontend/app/routes/protected/in-person/privacy-statement.tsx
+++ b/frontend/app/routes/protected/in-person/privacy-statement.tsx
@@ -6,7 +6,7 @@ import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
-import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service';
+import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service.server';
 
 export async function action({ context, params, request }: Route.ActionArgs) {
   const actor = loadMachineActor(context.session, request, 'privacy-statement');

--- a/frontend/app/routes/protected/in-person/request-details.tsx
+++ b/frontend/app/routes/protected/in-person/request-details.tsx
@@ -1,4 +1,4 @@
-import { Form, redirect, useOutletContext } from 'react-router';
+import { Form, redirect } from 'react-router';
 
 import type { Route } from './+types/request-details';
 
@@ -6,16 +6,10 @@ import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
-import { getRoute, load } from '~/routes/protected/in-person/state-machine';
+import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service';
 
 export async function action({ context, params, request }: Route.ActionArgs) {
-  const tabId = new URL(request.url).searchParams.get('tid');
-
-  if (!tabId) {
-    return Response.json('Tab id is required; it must not be null or empty', { status: 400 });
-  }
-
-  const actor = load(context.session, tabId);
+  const actor = loadMachineActor(context.session, request, 'request-details');
 
   const formData = await request.formData();
   const action = formData.get('action');
@@ -41,17 +35,20 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     }
   }
 
-  throw redirect(getRoute(actor, { context, params, request }));
+  throw redirect(getStateRoute(actor, { context, params, request }));
+}
+
+export function loader({ context, params, request }: Route.LoaderArgs) {
+  loadMachineActor(context.session, request, 'request-details');
+  return { tabId: new URL(request.url).searchParams.get('tid') };
 }
 
 export default function RequestDetails({ actionData, loaderData, matches, params }: Route.ComponentProps) {
-  const { tabId } = useOutletContext<{ tabId: string }>();
-
   return (
     <div className="space-y-3">
       <PageTitle>
         <span>Request details</span>
-        <span className="block text-sm">(tabid: {tabId})</span>
+        <span className="block text-sm">(tabid: {loaderData.tabId})</span>
       </PageTitle>
       <Form method="post">
         <div className="space-x-3">

--- a/frontend/app/routes/protected/in-person/request-details.tsx
+++ b/frontend/app/routes/protected/in-person/request-details.tsx
@@ -6,7 +6,7 @@ import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
-import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service';
+import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service.server';
 
 export async function action({ context, params, request }: Route.ActionArgs) {
   const actor = loadMachineActor(context.session, request, 'request-details');

--- a/frontend/app/routes/protected/in-person/review.tsx
+++ b/frontend/app/routes/protected/in-person/review.tsx
@@ -1,4 +1,4 @@
-import { Form, redirect, useOutletContext } from 'react-router';
+import { Form, redirect } from 'react-router';
 
 import type { Route } from './+types/review';
 
@@ -6,16 +6,10 @@ import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
-import { getRoute, load } from '~/routes/protected/in-person/state-machine';
+import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service';
 
 export async function action({ context, params, request }: Route.ActionArgs) {
-  const tabId = new URL(request.url).searchParams.get('tid');
-
-  if (!tabId) {
-    return Response.json('Tab id is required; it must not be null or empty', { status: 400 });
-  }
-
-  const actor = load(context.session, tabId);
+  const actor = loadMachineActor(context.session, request, 'review');
 
   const formData = await request.formData();
   const action = formData.get('action');
@@ -36,17 +30,20 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     }
   }
 
-  throw redirect(getRoute(actor, { context, params, request }));
+  throw redirect(getStateRoute(actor, { context, params, request }));
+}
+
+export function loader({ context, params, request }: Route.LoaderArgs) {
+  loadMachineActor(context.session, request, 'review');
+  return { tabId: new URL(request.url).searchParams.get('tid') };
 }
 
 export default function Review({ actionData, loaderData, matches, params }: Route.ComponentProps) {
-  const { tabId } = useOutletContext<{ tabId: string }>();
-
   return (
     <div className="space-y-3">
       <PageTitle>
         <span>Review</span>
-        <span className="block text-sm">(tabid: {tabId})</span>
+        <span className="block text-sm">(tabid: {loaderData.tabId})</span>
       </PageTitle>
       <Form method="post">
         <div className="space-x-3">

--- a/frontend/app/routes/protected/in-person/review.tsx
+++ b/frontend/app/routes/protected/in-person/review.tsx
@@ -6,7 +6,7 @@ import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
-import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service';
+import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service.server';
 
 export async function action({ context, params, request }: Route.ActionArgs) {
   const actor = loadMachineActor(context.session, request, 'review');

--- a/frontend/app/routes/protected/in-person/secondary-docs.tsx
+++ b/frontend/app/routes/protected/in-person/secondary-docs.tsx
@@ -1,4 +1,4 @@
-import { Form, redirect, useOutletContext } from 'react-router';
+import { Form, redirect } from 'react-router';
 
 import type { Route } from './+types/secondary-docs';
 
@@ -6,16 +6,10 @@ import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
-import { getRoute, load } from '~/routes/protected/in-person/state-machine';
+import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service';
 
 export async function action({ context, params, request }: Route.ActionArgs) {
-  const tabId = new URL(request.url).searchParams.get('tid');
-
-  if (!tabId) {
-    return Response.json('Tab id is required; it must not be null or empty', { status: 400 });
-  }
-
-  const actor = load(context.session, tabId);
+  const actor = loadMachineActor(context.session, request, 'secondary-docs');
 
   const formData = await request.formData();
   const action = formData.get('action');
@@ -41,17 +35,20 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     }
   }
 
-  throw redirect(getRoute(actor, { context, params, request }));
+  throw redirect(getStateRoute(actor, { context, params, request }));
+}
+
+export function loader({ context, params, request }: Route.LoaderArgs) {
+  loadMachineActor(context.session, request, 'secondary-docs');
+  return { tabId: new URL(request.url).searchParams.get('tid') };
 }
 
 export default function SecondayDocs({ actionData, loaderData, matches, params }: Route.ComponentProps) {
-  const { tabId } = useOutletContext<{ tabId: string }>();
-
   return (
     <div className="space-y-3">
       <PageTitle>
         <span>Secondary docs</span>
-        <span className="block text-sm">(tabid: {tabId})</span>
+        <span className="block text-sm">(tabid: {loaderData.tabId})</span>
       </PageTitle>
       <Form method="post">
         <div className="space-x-3">

--- a/frontend/app/routes/protected/in-person/secondary-docs.tsx
+++ b/frontend/app/routes/protected/in-person/secondary-docs.tsx
@@ -6,7 +6,7 @@ import { Button } from '~/components/button';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
-import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service';
+import { getStateRoute, loadMachineActor } from '~/routes/protected/in-person/state-machine-service.server';
 
 export async function action({ context, params, request }: Route.ActionArgs) {
   const actor = loadMachineActor(context.session, request, 'secondary-docs');

--- a/frontend/app/routes/protected/in-person/state-machine-service.server.ts
+++ b/frontend/app/routes/protected/in-person/state-machine-service.server.ts
@@ -5,11 +5,12 @@ import type { Actor } from 'xstate';
 import { createActor } from 'xstate';
 
 import { LogFactory } from '~/.server/logging';
+import { i18nRedirect } from '~/.server/utils/route-utils';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
 import { i18nRoutes } from '~/i18n-routes';
-import type { StateName } from '~/routes/protected/in-person/state-machine';
-import { machine } from '~/routes/protected/in-person/state-machine';
+import type { StateName } from '~/routes/protected/in-person/state-machine.server';
+import { machine } from '~/routes/protected/in-person/state-machine.server';
 import { getLanguage } from '~/utils/i18n-utils';
 import { getRouteByFile } from '~/utils/route-utils';
 
@@ -59,19 +60,19 @@ export function loadMachineActor(session: AppSession, request: Request, state: S
   const tabId = new URL(request.url).searchParams.get('tid');
 
   if (!tabId) {
-    // XXX :: GjB :: how should we handle this case?
-    //               Showing an error page seems like bad UX.
-    log.warn('Could not find tabId in request; returning 400 response.');
-    throw Response.json('The tabId could not be found in the request', { status: 400 });
+    // XXX :: GjB :: I think adding a search param (or something) to indicate to
+    //               index.tsx that this happened would be beneficial.
+    //               This would allow us to show a message to the user explaining the situation.
+    log.warn('Could not find tabId in request; redirecting to start of flow');
+    throw i18nRedirect('routes/protected/in-person/index.tsx', request);
   }
 
   if (!flow[tabId]) {
-    // XXX :: GjB :: how should we handle this case?
-    //               Showing an error page seems like bad UX.
-    throw new AppError(
-      'The machine snapshot was not found in session', //
-      ErrorCodes.MISSING_SNAPSHOT,
-    );
+    // XXX :: GjB :: I think adding a search param (or something) to indicate to
+    //               index.tsx that this happened would be beneficial.
+    //               This would allow us to show a message to the user explaining the situation.
+    log.warn('Could not find a machine snapshot session; redirecting to start of flow');
+    throw i18nRedirect('routes/protected/in-person/index.tsx', request);
   }
 
   const snapshot = machine.resolveState({ value: state, context: flow[tabId].context });

--- a/frontend/app/routes/protected/in-person/state-machine-service.ts
+++ b/frontend/app/routes/protected/in-person/state-machine-service.ts
@@ -1,0 +1,114 @@
+import type { ActionFunctionArgs } from 'react-router';
+import { generatePath } from 'react-router';
+
+import type { Actor } from 'xstate';
+import { createActor } from 'xstate';
+
+import { LogFactory } from '~/.server/logging';
+import { AppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
+import { i18nRoutes } from '~/i18n-routes';
+import type { StateName } from '~/routes/protected/in-person/state-machine';
+import { machine } from '~/routes/protected/in-person/state-machine';
+import { getLanguage } from '~/utils/i18n-utils';
+import { getRouteByFile } from '~/utils/route-utils';
+
+type Machine = typeof machine;
+
+const log = LogFactory.getLogger(import.meta.url);
+
+/**
+ * Creates a new in-person application state machine actor and stores it in the session.
+ *
+ * This function retrieves the `tabId` from the request URL, creates a new XState actor
+ * for the in-person application flow, subscribes to its state changes to persist
+ * the snapshot in the session, and starts the actor.
+ *
+ * @throws {Response} 400 response if the `tabId` is missing in the request.
+ */
+export function createMachineActor(session: AppSession, request: Request): Actor<Machine> {
+  const flow = (session.inPersonFlow ??= {}); // ensure session container exists
+
+  const tabId = new URL(request.url).searchParams.get('tid');
+
+  if (!tabId) {
+    log.warn('Could not find tabId in request; returning 400 response.');
+    throw Response.json('The tabId could not be found in the request', { status: 400 });
+  }
+
+  const actor = createActor(machine);
+  actor.subscribe((snapshot) => void (flow[tabId] = snapshot));
+  log.debug('Created new in-person state machine for session [%s] and tabId [%s]', session.id, tabId);
+
+  return actor.start();
+}
+
+/**
+ * Loads an existing in-person application state machine actor from the session.
+ *
+ * This function retrieves the `tabId` from the request URL, attempts to load a
+ * persisted XState actor snapshot from the session, and recreates the actor
+ * with the loaded snapshot.
+ *
+ * @throws {AppError} If the machine snapshot is not found in the session.
+ * @throws {Response} 400 response if the `tabId` is missing in the request.
+ */
+export function loadMachineActor(session: AppSession, request: Request, state: StateName): Actor<Machine> {
+  const flow = (session.inPersonFlow ??= {}); // ensure session container exists
+
+  const tabId = new URL(request.url).searchParams.get('tid');
+
+  if (!tabId) {
+    // XXX :: GjB :: how should we handle this case?
+    //               Showing an error page seems like bad UX.
+    log.warn('Could not find tabId in request; returning 400 response.');
+    throw Response.json('The tabId could not be found in the request', { status: 400 });
+  }
+
+  if (!flow[tabId]) {
+    // XXX :: GjB :: how should we handle this case?
+    //               Showing an error page seems like bad UX.
+    throw new AppError(
+      'The machine snapshot was not found in session', //
+      ErrorCodes.MISSING_SNAPSHOT,
+    );
+  }
+
+  const snapshot = machine.resolveState({ value: state, context: flow[tabId].context });
+  const actor = createActor(machine, { snapshot });
+  actor.subscribe((snapshot) => void (flow[tabId] = snapshot));
+  log.debug('Loaded in-person state machine for session [%s] and tabId [%s]', session.id, tabId);
+
+  return actor.start();
+}
+
+/**
+ * Generates a URL for a given machine state and arguments.
+ *
+ * This function determines the appropriate route based on the current machine state,
+ * language, and provided arguments. It retrieves metadata associated with the state,
+ * uses it to find the correct route definition, and constructs the URL using the provided
+ * parameters. It throws an error if the language cannot be determined from the request
+ * or if the metadata for the current machine state cannot be found.
+ *
+ * @throws {AppError} If the language or metadata cannot be determined.
+ */
+export function getStateRoute(actor: Actor<Machine>, { params, request }: ActionFunctionArgs): string {
+  const language = getLanguage(request);
+
+  if (!language) {
+    throw new AppError(
+      'The current language could not be determined from the request', //
+      ErrorCodes.MISSING_LANG_PARAM,
+    );
+  }
+
+  const { context, value } = actor.getSnapshot();
+  const i18nRouteFile = context.routes[value];
+
+  const url = new URL(request.url);
+  const { paths } = getRouteByFile(i18nRouteFile, i18nRoutes);
+  url.pathname = generatePath(paths[language], params);
+
+  return url.toString();
+}

--- a/frontend/app/routes/protected/in-person/state-machine.server.ts
+++ b/frontend/app/routes/protected/in-person/state-machine.server.ts
@@ -37,7 +37,7 @@ export const routes = {
   'previous-sin-info': 'routes/protected/in-person/previous-sin-info.tsx',
   'contact-info': 'routes/protected/in-person/contact-info.tsx',
   'review': 'routes/protected/in-person/review.tsx',
-} satisfies Record<StateName, I18nRouteFile>;
+} as const satisfies Record<StateName, I18nRouteFile>;
 
 /**
  * XState machine definition for the in-person application process.

--- a/frontend/app/routes/protected/in-person/types.d.ts
+++ b/frontend/app/routes/protected/in-person/types.d.ts
@@ -1,7 +1,7 @@
 import 'express-session';
 import type { SnapshotFrom } from 'xstate';
 
-import type { machine } from '~/routes/protected/in-person/state-machine';
+import type { machine } from '~/routes/protected/in-person/state-machine.server';
 
 type Snapshot = SnapshotFrom<typeof machine>;
 

--- a/frontend/app/routes/protected/in-person/types.d.ts
+++ b/frontend/app/routes/protected/in-person/types.d.ts
@@ -3,11 +3,11 @@ import type { SnapshotFrom } from 'xstate';
 
 import type { machine } from '~/routes/protected/in-person/state-machine';
 
-type MachineType = SnapshotFrom<typeof machine>;
+type Snapshot = SnapshotFrom<typeof machine>;
 
 declare module 'express-session' {
   interface SessionData {
-    inPersonFlow: Record<string, MachineType | undefined>;
+    inPersonFlow: Record<string, Snapshot | undefined>;
   }
 }
 

--- a/frontend/tests/routes/protected/in-person/state-machine.test.ts
+++ b/frontend/tests/routes/protected/in-person/state-machine.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { createActor } from 'xstate';
 
-import { machine, routes } from '~/routes/protected/in-person/state-machine';
+import { machine, routes } from '~/routes/protected/in-person/state-machine.server';
 
 describe('in-person machine transitions', () => {
   const states = [

--- a/frontend/tests/routes/protected/in-person/state-machine.test.ts
+++ b/frontend/tests/routes/protected/in-person/state-machine.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { createActor } from 'xstate';
 
-import { machine } from '~/routes/protected/in-person/state-machine';
+import { machine, routes } from '~/routes/protected/in-person/state-machine';
 
 describe('in-person machine transitions', () => {
   const states = [
@@ -17,7 +17,7 @@ describe('in-person machine transitions', () => {
     'previous-sin-info',
     'contact-info',
     'review',
-  ] as const;
+  ];
 
   const prevStates = Object.entries({
     'request-details': 'privacy-statement',
@@ -29,7 +29,7 @@ describe('in-person machine transitions', () => {
     'parent-info': 'birth-info',
     'previous-sin-info': 'parent-info',
     'contact-info': 'previous-sin-info',
-  } as const);
+  });
 
   const nextStates = Object.entries({
     'start': 'privacy-statement',
@@ -43,10 +43,10 @@ describe('in-person machine transitions', () => {
     'parent-info': 'previous-sin-info',
     'previous-sin-info': 'contact-info',
     'contact-info': 'review',
-  } as const);
+  });
 
   it.each(nextStates)('should transition from %s to %s on next event', (from, to) => {
-    const state = machine.resolveState({ value: from });
+    const state = machine.resolveState({ context: { routes }, value: from });
     const actor = createActor(machine, { state }).start();
 
     actor.send({ type: 'next' });
@@ -55,7 +55,7 @@ describe('in-person machine transitions', () => {
   });
 
   it.each(prevStates)('should transition from %s to %s on prev event', (from, to) => {
-    const state = machine.resolveState({ value: from });
+    const state = machine.resolveState({ context: { routes }, value: from });
     const actor = createActor(machine, { state }).start();
 
     actor.send({ type: 'prev' });
@@ -64,7 +64,7 @@ describe('in-person machine transitions', () => {
   });
 
   it.each(states.filter((state) => state !== 'start'))('should transition from %s to start on cancel', (from) => {
-    const state = machine.resolveState({ value: from });
+    const state = machine.resolveState({ context: { routes }, value: from });
     const actor = createActor(machine, { state }).start();
 
     actor.send({ type: 'cancel' });


### PR DESCRIPTION
[AB#15081](https://dev.azure.com/ESDCCM/a4b4f7af-bbd7-4f0d-83ab-a123d0b70fda/_workitems/edit/15081) -- Explore XState for managing wizard screen flow

## Summary

Refactoring to how the xstate stuff works.

- Allowing for target-state loading when hitting a route. This prevents the state machine from desynchronizing with the application URL. When you hit `/my-route` then the correct state for `my-route` is loaded.
- Moving some repeated code into helper functions.
- Strict-typing the state names to ensure some of the helper functions are called correctly.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [x] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [x] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [x] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [x] documentation has been updated to reflect the changes
- [x] linked this PR to a related issue
