### PR TITLE
(frontend): add document type field on primary identification screen

### DIFF
--- a/frontend/app/.server/locales/protected-en.json
+++ b/frontend/app/.server/locales/protected-en.json
@@ -53,6 +53,7 @@
       "required": "Current status in Canada is required.",
       "invalid": "Please select Canadian Citizen born outside Canada.",
       "options": {
+        "select-option": "Select option",
         "canadian-citizen-born-in-canada": "Canadian citizen born in Canada",
         "canadian-citizen-born-outside-canada": "Canadian citizen born outside Canada",
         "registered-indian-born-in-canada": "Registered Indian born in Canada",
@@ -62,7 +63,17 @@
         "no-legal-status-in-canada": "No Legal Status in Canada"
       }
     },
-    "please-select": "Please select",
+    "document-type": {
+      "title": "Document type",
+      "required": "Document type is required.",
+      "options": {
+        "select-option": "Select option",
+        "certificate-of-canadian-citizenship": "Certificate of Canadian citizenship",
+        "certificate-of-registration-of-birth-abroad": "Certificate of Registration of Birth Abroad",
+        "birth-certificate-and-certificate-of-indian-status": "Birth certificates and Certificates of Indian Status",
+        "certificate-of-canadian-citizenship-and-certificate-of-indian-status": "Certificate of Canadian Citizenship and Certificate of Indian Status"
+      }
+    },
     "page-title": "Primary identity document"
   },
   "request-details": {

--- a/frontend/app/.server/locales/protected-fr.json
+++ b/frontend/app/.server/locales/protected-fr.json
@@ -53,6 +53,7 @@
       "required": "Statut actuel au Canada est requis.",
       "invalid": "Veuillez sélectionner un citoyen canadien né en dehors du Canada.",
       "options": {
+        "select-option": "Sélectionner une option",
         "canadian-citizen-born-in-canada": "Citoyen canadien né au Canada",
         "canadian-citizen-born-outside-canada": "Citoyen canadien né à l'extérieur du Canada",
         "registered-indian-born-in-canada": "Indien enregistré né au Canada",
@@ -62,7 +63,17 @@
         "no-legal-status-in-canada": "Aucun statut légal au Canada"
       }
     },
-    "please-select": "Veuillez sélectionner",
+    "document-type": {
+      "title": "Type de document",
+      "required": "Le type de document est requis.",
+      "options": {
+        "select-option": "Sélectionner une option",
+        "certificate-of-canadian-citizenship": "Certificat de citoyenneté canadienne",
+        "certificate-of-registration-of-birth-abroad": "Certificat d'enregistrement de naissance à l'étranger",
+        "birth-certificate-and-certificate-of-indian-status": "Certificats de naissance et certificats de statut indien",
+        "certificate-of-canadian-citizenship-and-certificate-of-indian-status": "Certificat de citoyenneté canadienne et certificat de statut indien"
+      }
+    },
     "page-title": "Document d'identité principal"
   },
   "request-details": {

--- a/frontend/app/@types/express-session.d.ts
+++ b/frontend/app/@types/express-session.d.ts
@@ -34,7 +34,10 @@ declare module 'express-session' {
         type: string;
         scenario: string;
       };
-      currentStatusInCanada?: string;
+      primaryDocuments?: {
+        currentStatusInCanada: string;
+        documentType: string;
+      };
     };
   }
 }


### PR DESCRIPTION
## Summary

Work item: [#14682](https://dev.azure.com/ESDCCM/FSIR/_workitems/edit/14682)
Add document type field on primary identification screen
User is presented with the Current Status options. Based on the correct options "Canadian citizen born outside Canada" or "Registered Indian born in Canada" in current status, the document type show respective options.
On pressing next button, field is validated. Correct validation for proof of concept is "Canadian citizen born outside Canada"

The document type is validated for null value.



## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

![image](https://github.com/user-attachments/assets/7d92d4a3-91d2-427c-b740-c98d286066a2)
![image](https://github.com/user-attachments/assets/787cc42a-c653-4be6-956b-e27100e1354e)
