### PR TITLE
feat(frontend): add `isValidTimeZone()` function

### DIFF
--- a/frontend/app/utils/date-utils.ts
+++ b/frontend/app/utils/date-utils.ts
@@ -51,3 +51,21 @@ export function getLocalizedMonths(
     text: formatter.format(Date.UTC(0, i, 1)), // formatted month name
   }));
 }
+
+/**
+ * Checks if a given string is a valid time zone.
+ *
+ * see: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+ *
+ * @param timeZone - The time zone string to validate.
+ * @returns `true` if the time zone is valid, `false` if it is not
+ */
+export function isValidTimeZone(timeZone: string): boolean {
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone });
+  } catch {
+    return false;
+  }
+
+  return true;
+}

--- a/frontend/tests/utils/date-utils.test.ts
+++ b/frontend/tests/utils/date-utils.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { isValidTimeZone } from '~/utils/date-utils';
+
+describe('date-utils', () => {
+  describe('isValidTimeZone', () => {
+    it('should return true for valid timezones', () => {
+      expect(isValidTimeZone('UTC')).toEqual(true);
+      expect(isValidTimeZone('Canada/Newfoundland')).toEqual(true);
+      expect(isValidTimeZone('Canada/Atlantic')).toEqual(true);
+      expect(isValidTimeZone('Canada/Central')).toEqual(true);
+      expect(isValidTimeZone('Canada/Mountain')).toEqual(true);
+      expect(isValidTimeZone('Canada/Pacific')).toEqual(true);
+    });
+
+    it('should return false for invalid timezones', () => {
+      expect(isValidTimeZone('')).toEqual(false);
+      expect(isValidTimeZone('Canada')).toEqual(false);
+      expect(isValidTimeZone('MyTimezone!')).toEqual(false);
+      expect(isValidTimeZone('Canada/Los_Angeles')).toEqual(false);
+    });
+  });
+});

--- a/frontend/tests/utils/date-utils.test.ts
+++ b/frontend/tests/utils/date-utils.test.ts
@@ -4,20 +4,28 @@ import { isValidTimeZone } from '~/utils/date-utils';
 
 describe('date-utils', () => {
   describe('isValidTimeZone', () => {
-    it('should return true for valid timezones', () => {
-      expect(isValidTimeZone('UTC')).toEqual(true);
-      expect(isValidTimeZone('Canada/Newfoundland')).toEqual(true);
-      expect(isValidTimeZone('Canada/Atlantic')).toEqual(true);
-      expect(isValidTimeZone('Canada/Central')).toEqual(true);
-      expect(isValidTimeZone('Canada/Mountain')).toEqual(true);
-      expect(isValidTimeZone('Canada/Pacific')).toEqual(true);
+    const invalidTimeZones = [
+      '', //
+      'Canada',
+      'Canada/Los_Angeles',
+      'MyTimeZone!!',
+    ];
+
+    const validTimeZones = [
+      'Canada/Atlantic',
+      'Canada/Central',
+      'Canada/Mountain',
+      'Canada/Newfoundland',
+      'Canada/Pacific',
+      'UTC',
+    ];
+
+    it.each(invalidTimeZones)('should return [false] for invalid time zone [%s]', (timeZone) => {
+      expect(isValidTimeZone(timeZone)).toEqual(false);
     });
 
-    it('should return false for invalid timezones', () => {
-      expect(isValidTimeZone('')).toEqual(false);
-      expect(isValidTimeZone('Canada')).toEqual(false);
-      expect(isValidTimeZone('MyTimezone!')).toEqual(false);
-      expect(isValidTimeZone('Canada/Los_Angeles')).toEqual(false);
+    it.each(validTimeZones)('should return [true] for valid time zone [%s]', (timeZone) => {
+      expect(isValidTimeZone(timeZone)).toEqual(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

This PR adds an `isValidTimeZone()` function to `app/utils/date-utils.ts` so it can be used in an up coming PR.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)
