### PR TITLE
feat(frontend): add `BASE_TIMEZONE` envar

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -17,6 +17,10 @@ PORT=
 # Set to true to log additional information about translations and potential issues.
 I18NEXT_DEBUG=
 
+# The base timezone to use when performing date calculations (default Canada/Eastern).
+# see: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+BASE_TIMEZONE=
+
 
 
 #################################################

--- a/frontend/app/.server/environment/server.ts
+++ b/frontend/app/.server/environment/server.ts
@@ -9,12 +9,14 @@ import { session, defaults as sessionDefaults } from '~/.server/environment/sess
 import { telemetry, defaults as telemetryDefaults } from '~/.server/environment/telemetry';
 import { LogFactory } from '~/.server/logging';
 import { stringToIntegerSchema } from '~/.server/validation/string-to-integer-schema';
+import { isValidTimeZone } from '~/utils/date-utils';
 
 const log = LogFactory.getLogger(import.meta.url);
 
 export type Server = Readonly<v.InferOutput<typeof server>>;
 
 export const defaults = {
+  BASE_TIMEZONE: 'Canada/Eastern',
   NODE_ENV: 'development',
   PORT: '3000',
   ...authenticationDefaults,
@@ -39,6 +41,7 @@ export const server = v.pipe(
     ...redis.entries,
     ...session.entries,
     ...telemetry.entries,
+    BASE_TIMEZONE: v.optional(v.pipe(v.string(), v.check(isValidTimeZone)), defaults.BASE_TIMEZONE),
     NODE_ENV: v.optional(v.picklist(['production', 'development', 'test']), defaults.NODE_ENV),
     PORT: v.optional(v.pipe(stringToIntegerSchema(), v.minValue(0)), defaults.PORT),
   }),


### PR DESCRIPTION
## Summary

This PR adds a `BASE_TIMEZONE` configuration option that will eventually be used when performing date (without timestamp) calculations in the application.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [x] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [x] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)
