### PR TITLE
chore(frontend): enhance JSDoc in `i18n-routes.ts`

### DIFF
--- a/frontend/app/i18n-routes.ts
+++ b/frontend/app/i18n-routes.ts
@@ -1,16 +1,65 @@
+/*
+ *
+ * This file defines the structure and types for internationalized (i18n) routes.
+ * It provides a way to represent routes with different paths for different languages.
+ *
+ * The `i18nRoutes` constant holds the configuration for these routes, which are then
+ * transformed into react-router `RouteConfigEntry` objects in `routes.ts`. This
+ * separation allows the i18n route definitions to be imported and used in client-side
+ * code when generating links.
+ *
+ */
+
+/**
+ * Represents a record of paths for different languages.
+ * Key: Language code (e.g., 'en', 'fr').
+ * Value: A path for that language (ex: /en/about or /fr/a-propos).
+ */
 type I18nPaths = Record<Language, string>;
+
+/**
+ * A utility typpe that extracts the file path from an I18nPageRoute type.
+ * @template T - The type to extract the file from.
+ */
 type ExtractI18nRouteFile<T> = T extends I18nPageRoute ? T['file'] : never;
-type ExtractI18nRouteFiles<T, Filter = void> = T extends I18nLayoutRoute
-  ? ExtractI18nRouteFiles<T['children'][number], Filter>
+
+/**
+ * A utility type that recursively extracts all file paths from an array of I18nRoute objects.
+ * @template T - The type of the I18nRoute array.
+ */
+type ExtractI18nRouteFiles<T> = T extends I18nLayoutRoute
+  ? ExtractI18nRouteFiles<T['children'][number]>
   : ExtractI18nRouteFile<T>;
 
+/**
+ * Represents a route that can be either a layout route or a page route.
+ */
 export type I18nRoute = I18nLayoutRoute | I18nPageRoute;
+
+/**
+ * Represents a layout route, which contains other routes as children.
+ * @property file - The file path for the layout component.
+ * @property children - An array of child I18nRoute objects.
+ */
 export type I18nLayoutRoute = { file: string; children: I18nRoute[] };
+
+/**
+ * Represents a page route, which has specific paths for different languages.
+ * @property id - A unique identifier for the route.
+ * @property file - The file path for the page component.
+ * @property paths - An I18nPaths object containing paths for different languages.
+ */
 export type I18nPageRoute = { id: string; file: string; paths: I18nPaths };
+
+/**
+ * Represents all file paths used in the i18n routes.
+ */
 export type I18nRouteFile = ExtractI18nRouteFiles<(typeof i18nRoutes)[number]>;
 
 /**
  * Type guard to determine if a route is an I18nLayoutRoute.
+ * @param obj - The object to check.
+ * @returns `true` if the object is an I18nLayoutRoute, `false` otherwise.
  */
 export function isI18nLayoutRoute(obj: unknown): obj is I18nLayoutRoute {
   return obj !== null && typeof obj === 'object' && 'file' in obj && 'children' in obj;
@@ -18,6 +67,8 @@ export function isI18nLayoutRoute(obj: unknown): obj is I18nLayoutRoute {
 
 /**
  * Type guard to determine if a route is an I18nPageRoute.
+ * @param obj - The object to check.
+ * @returns `true` if the object is an I18nPageRoute, `false` otherwise.
  */
 export function isI18nPageRoute(obj: unknown): obj is I18nPageRoute {
   return obj !== null && typeof obj === 'object' && 'file' in obj && 'paths' in obj;
@@ -31,6 +82,9 @@ export function isI18nPageRoute(obj: unknown): obj is I18nPageRoute {
  * be imported into clientside code without triggering side effects.
  */
 export const i18nRoutes = [
+  //
+  // Protected routes (ie: authentication required)
+  //
   {
     file: 'routes/protected/layout.tsx',
     children: [
@@ -197,6 +251,9 @@ export const i18nRoutes = [
       },
     ],
   },
+  //
+  // Publicly accessable routes (ie: no authentication required)
+  //
   {
     file: 'routes/public/layout.tsx',
     children: [


### PR DESCRIPTION
## Summary

Add some LLM-generated JSDoc to `i18n-routes.ts` for an improved DX.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [x] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

When I pasted the `i18n-routes.ts` file into Google Gemini, it told me that the `Filter` template parameter used in `ExtractI18nRouteFiles` wasn't being used, so I removed it. Everything appears to function as before without it.
