### PR TITLE
refactor(frontend): move person-case session types

### DIFF
--- a/frontend/app/@types/express-session.d.ts
+++ b/frontend/app/@types/express-session.d.ts
@@ -2,18 +2,6 @@ import 'express-session';
 
 import type { IDTokenClaims } from '~/.server/auth/auth-strategies';
 
-type SupportingDocs =
-  | { supportingDocumentsRequired: false }
-  | { supportingDocumentsRequired: true; supportingDocumentTypes: string[] };
-
-type CurrentName =
-  | { preferredSameAsDocumentName: true }
-  | ({ preferredSameAsDocumentName: false; firstName: string; middleName?: string; lastName: string } & SupportingDocs);
-
-type BirthDetails =
-  | { country: 'CAN'; province: string; city: string; fromMultipleBirth: boolean }
-  | { country: string; province?: string; city?: string; fromMultipleBirth: boolean };
-
 declare module 'express-session' {
   interface SessionData {
     authState: {
@@ -26,45 +14,6 @@ declare module 'express-session' {
       nonce: string;
       returnUrl?: URL;
       state: string;
-    };
-    /**
-     * Represents the session data for the in-person SIN case.
-     */
-    inPersonSINCase: {
-      currentNameInfo?: CurrentName;
-      /**
-       * Represents the privacy statement data for the in-person SIN case.
-       */
-      privacyStatement?: {
-        /**
-         * Indicates whether the user has agreed to the terms of the privacy statement.
-         */
-        agreedToTerms: true;
-      };
-      requestDetails?: {
-        type: string;
-        scenario: string;
-      };
-      primaryDocuments?: {
-        currentStatusInCanada: string;
-        documentType: string;
-      };
-      previousSin?: {
-        hasPreviousSin: string;
-        socialInsuranceNumber?: string;
-      };
-      contactInformation?: {
-        preferredLanguage: string;
-        primaryPhoneNumber: string;
-        secondaryPhoneNumber?: string;
-        emailAddress?: string;
-        country: string;
-        address: string;
-        postalCode: string;
-        city: string;
-        province: string;
-      };
-      birthDetails?: BirthDetails;
     };
   }
 }

--- a/frontend/app/routes/protected/person-case/@types.d.ts
+++ b/frontend/app/routes/protected/person-case/@types.d.ts
@@ -1,0 +1,46 @@
+import 'express-session';
+
+type SupportingDocs =
+  | { supportingDocumentsRequired: false }
+  | { supportingDocumentsRequired: true; supportingDocumentTypes: string[] };
+
+declare module 'express-session' {
+  interface SessionData {
+    inPersonSINCase: Partial<{
+      currentNameInfo:
+        | { preferredSameAsDocumentName: true }
+        | ({ preferredSameAsDocumentName: false; firstName: string; middleName?: string; lastName: string } & SupportingDocs);
+      privacyStatement: {
+        agreedToTerms: true;
+      };
+      requestDetails: {
+        type: string;
+        scenario: string;
+      };
+      primaryDocuments: {
+        currentStatusInCanada: string;
+        documentType: string;
+      };
+      previousSin: {
+        hasPreviousSin: string;
+        socialInsuranceNumber?: string;
+      };
+      contactInformation: {
+        preferredLanguage: string;
+        primaryPhoneNumber: string;
+        secondaryPhoneNumber?: string;
+        emailAddress?: string;
+        country: string;
+        address: string;
+        postalCode: string;
+        city: string;
+        province: string;
+      };
+      birthDetails:
+        | { country: 'CAN'; province: string; city: string; fromMultipleBirth: boolean }
+        | { country: string; province?: string; city?: string; fromMultipleBirth: boolean };
+    }>;
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary

This PR moves the in-person session types into a localized `@types.d.ts` file in the `routes/in-person/` folder.

## Why

The global `@types/express-session.d.ts` file was intended to be used to define more application-wide session types (for example, if the user is authenticated). Polluting this file with route-specific session types will make it difficult to manage over time, because deprecated and unused types might be left to rot.

By moving the route-specific types into the `app/routes/` folder, it makes managing these types a little easier.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)
