### PR TITLE
feat(frontend): emit runtime config at startup

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -13,7 +13,7 @@ LOG_LEVEL=
 # Specify the port used to serve the application.
 PORT=
 
-# Enables debug logging for the i18next localization library (default: false).
+# Enables debug logging for the i18next localization library (default: undefined).
 # Set to true to log additional information about translations and potential issues.
 I18NEXT_DEBUG=
 

--- a/frontend/app/.server/environment/client.ts
+++ b/frontend/app/.server/environment/client.ts
@@ -6,7 +6,6 @@ import { stringToBooleanSchema } from '~/.server/validation/string-to-boolean-sc
 export type Client = Readonly<v.InferOutput<typeof client>>;
 
 export const defaults = {
-  I18NEXT_DEBUG: 'false',
   ...buildinfoDefaults,
 } as const;
 
@@ -16,6 +15,6 @@ export const defaults = {
  */
 export const client = v.object({
   ...buildinfo.entries,
-  I18NEXT_DEBUG: v.optional(stringToBooleanSchema(), defaults.I18NEXT_DEBUG),
+  I18NEXT_DEBUG: v.optional(stringToBooleanSchema()),
   isProduction: v.boolean(),
 });

--- a/frontend/app/.server/express/server.ts
+++ b/frontend/app/.server/express/server.ts
@@ -81,6 +81,10 @@ app.all('*', rrRequestHandler(viteDevServer));
 log.info('  ✓ registering global error handler');
 app.use(globalErrorHandler());
 
-log.info('Server initialization complete');
+log.info('Server initialization completed with runtime configuration: %o', {
+  client: Object.fromEntries(Object.entries(clientEnvironment).sort()),
+  server: Object.fromEntries(Object.entries(serverEnvironment).sort()),
+});
+
 const server = app.listen(serverEnvironment.PORT);
 log.info('Listening on http://localhost:%s/', (server.address() as AddressInfo).port);


### PR DESCRIPTION
## Summary

This PR enhances DX and OX by emitting the current runtime config at startup.

It also removes the default value from `I18NEXT_DEBUG` to reduce the amount of data being sent to the client (setting this to `undefined` is functionally equivalent).

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [x] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)
