### PR TITLE
feat(frontend): implement a `Redacted()` feature

### DIFF
--- a/frontend/app/.server/environment/authentication.ts
+++ b/frontend/app/.server/environment/authentication.ts
@@ -1,5 +1,6 @@
-import { Redacted } from 'effect';
 import * as v from 'valibot';
+
+import { Redacted } from '~/.server/utils/security-utils';
 
 export type Authentication = Readonly<v.InferOutput<typeof authentication>>;
 
@@ -14,5 +15,5 @@ export const authentication = v.object({
 
   AZUREAD_ISSUER_URL: v.optional(v.string()),
   AZUREAD_CLIENT_ID: v.optional(v.string()),
-  AZUREAD_CLIENT_SECRET: v.optional(v.pipe(v.string(), v.transform(Redacted.make))),
+  AZUREAD_CLIENT_SECRET: v.optional(v.pipe(v.string(), v.transform(Redacted<string>))),
 });

--- a/frontend/app/.server/environment/authentication.ts
+++ b/frontend/app/.server/environment/authentication.ts
@@ -15,5 +15,5 @@ export const authentication = v.object({
 
   AZUREAD_ISSUER_URL: v.optional(v.string()),
   AZUREAD_CLIENT_ID: v.optional(v.string()),
-  AZUREAD_CLIENT_SECRET: v.optional(v.pipe(v.string(), v.transform(Redacted<string>))),
+  AZUREAD_CLIENT_SECRET: v.optional(v.pipe(v.string(), v.transform(Redacted.make))),
 });

--- a/frontend/app/.server/environment/redis.ts
+++ b/frontend/app/.server/environment/redis.ts
@@ -18,7 +18,7 @@ export const redis = v.pipe(
     REDIS_HOST: v.optional(v.string(), defaults.REDIS_HOST),
     REDIS_PORT: v.optional(v.pipe(stringToIntegerSchema(), v.minValue(0)), defaults.REDIS_PORT),
     REDIS_USERNAME: v.optional(v.string()),
-    REDIS_PASSWORD: v.optional(v.pipe(v.string(), v.transform(Redacted<string>))),
+    REDIS_PASSWORD: v.optional(v.pipe(v.string(), v.transform(Redacted.make))),
     REDIS_SENTINEL_MASTER_NAME: v.optional(v.string()),
     REDIS_COMMAND_TIMEOUT_SECONDS: v.optional(
       v.pipe(stringToIntegerSchema(), v.minValue(0)),

--- a/frontend/app/.server/environment/redis.ts
+++ b/frontend/app/.server/environment/redis.ts
@@ -1,6 +1,6 @@
-import { Redacted } from 'effect';
 import * as v from 'valibot';
 
+import { Redacted } from '~/.server/utils/security-utils';
 import { stringToIntegerSchema } from '~/.server/validation/string-to-integer-schema';
 
 export type Redis = Readonly<v.InferOutput<typeof redis>>;
@@ -18,7 +18,7 @@ export const redis = v.pipe(
     REDIS_HOST: v.optional(v.string(), defaults.REDIS_HOST),
     REDIS_PORT: v.optional(v.pipe(stringToIntegerSchema(), v.minValue(0)), defaults.REDIS_PORT),
     REDIS_USERNAME: v.optional(v.string()),
-    REDIS_PASSWORD: v.optional(v.pipe(v.string(), v.transform(Redacted.make))),
+    REDIS_PASSWORD: v.optional(v.pipe(v.string(), v.transform(Redacted<string>))),
     REDIS_SENTINEL_MASTER_NAME: v.optional(v.string()),
     REDIS_COMMAND_TIMEOUT_SECONDS: v.optional(
       v.pipe(stringToIntegerSchema(), v.minValue(0)),

--- a/frontend/app/.server/environment/session.ts
+++ b/frontend/app/.server/environment/session.ts
@@ -1,6 +1,6 @@
-import { Redacted } from 'effect';
 import * as v from 'valibot';
 
+import { Redacted } from '~/.server/utils/security-utils';
 import { stringToBooleanSchema } from '~/.server/validation/string-to-boolean-schema';
 import { stringToIntegerSchema } from '~/.server/validation/string-to-integer-schema';
 
@@ -24,7 +24,7 @@ export const session = v.object({
   SESSION_COOKIE_PATH: v.optional(v.string(), defaults.SESSION_COOKIE_PATH),
   SESSION_COOKIE_SAMESITE: v.optional(v.picklist(['lax', 'strict', 'none']), defaults.SESSION_COOKIE_SAMESITE),
   SESSION_COOKIE_SECRET: v.optional(
-    v.pipe(v.string(), v.minLength(32), v.transform(Redacted.make)),
+    v.pipe(v.string(), v.minLength(32), v.transform(Redacted<string>)),
     defaults.SESSION_COOKIE_SECRET,
   ),
   SESSION_COOKIE_SECURE: v.optional(stringToBooleanSchema(), defaults.SESSION_COOKIE_SECURE),

--- a/frontend/app/.server/environment/session.ts
+++ b/frontend/app/.server/environment/session.ts
@@ -24,7 +24,7 @@ export const session = v.object({
   SESSION_COOKIE_PATH: v.optional(v.string(), defaults.SESSION_COOKIE_PATH),
   SESSION_COOKIE_SAMESITE: v.optional(v.picklist(['lax', 'strict', 'none']), defaults.SESSION_COOKIE_SAMESITE),
   SESSION_COOKIE_SECRET: v.optional(
-    v.pipe(v.string(), v.minLength(32), v.transform(Redacted<string>)),
+    v.pipe(v.string(), v.minLength(32), v.transform(Redacted.make)),
     defaults.SESSION_COOKIE_SECRET,
   ),
   SESSION_COOKIE_SECURE: v.optional(stringToBooleanSchema(), defaults.SESSION_COOKIE_SECURE),

--- a/frontend/app/.server/environment/telemetry.ts
+++ b/frontend/app/.server/environment/telemetry.ts
@@ -1,5 +1,6 @@
-import { Redacted } from 'effect';
 import * as v from 'valibot';
+
+import { Redacted } from '~/.server/utils/security-utils';
 
 export type Telemetry = Readonly<v.InferOutput<typeof telemetry>>;
 
@@ -16,7 +17,7 @@ export const telemetry = v.object({
   OTEL_SERVICE_NAME: v.optional(v.string(), defaults.OTEL_SERVICE_NAME),
   OTEL_SERVICE_VERSION: v.optional(v.string(), defaults.OTEL_SERVICE_VERSION),
   OTEL_ENVIRONMENT_NAME: v.optional(v.string(), defaults.OTEL_ENVIRONMENT_NAME),
-  OTEL_AUTH_HEADER: v.pipe(v.optional(v.string(), defaults.OTEL_AUTH_HEADER), v.transform(Redacted.make)),
+  OTEL_AUTH_HEADER: v.pipe(v.optional(v.string(), defaults.OTEL_AUTH_HEADER), v.transform(Redacted<string>)),
   OTEL_METRICS_ENDPOINT: v.optional(v.string(), defaults.OTEL_METRICS_ENDPOINT),
   OTEL_TRACES_ENDPOINT: v.optional(v.string(), defaults.OTEL_TRACES_ENDPOINT),
 });

--- a/frontend/app/.server/environment/telemetry.ts
+++ b/frontend/app/.server/environment/telemetry.ts
@@ -17,7 +17,7 @@ export const telemetry = v.object({
   OTEL_SERVICE_NAME: v.optional(v.string(), defaults.OTEL_SERVICE_NAME),
   OTEL_SERVICE_VERSION: v.optional(v.string(), defaults.OTEL_SERVICE_VERSION),
   OTEL_ENVIRONMENT_NAME: v.optional(v.string(), defaults.OTEL_ENVIRONMENT_NAME),
-  OTEL_AUTH_HEADER: v.pipe(v.optional(v.string(), defaults.OTEL_AUTH_HEADER), v.transform(Redacted<string>)),
+  OTEL_AUTH_HEADER: v.pipe(v.optional(v.string(), defaults.OTEL_AUTH_HEADER), v.transform(Redacted.make)),
   OTEL_METRICS_ENDPOINT: v.optional(v.string(), defaults.OTEL_METRICS_ENDPOINT),
   OTEL_TRACES_ENDPOINT: v.optional(v.string(), defaults.OTEL_TRACES_ENDPOINT),
 });

--- a/frontend/app/.server/express/middleware.ts
+++ b/frontend/app/.server/express/middleware.ts
@@ -1,5 +1,4 @@
 import { trace } from '@opentelemetry/api';
-import { Redacted } from 'effect';
 import type { RequestHandler } from 'express';
 import sessionMiddleware from 'express-session';
 import { minimatch } from 'minimatch';
@@ -133,7 +132,7 @@ export function session(environment: ServerEnvironment): RequestHandler {
   const middleware = sessionMiddleware({
     store: sessionStore,
     name: SESSION_COOKIE_NAME,
-    secret: [Redacted.value(SESSION_COOKIE_SECRET)],
+    secret: [SESSION_COOKIE_SECRET.value()],
     genid: () => randomUUID(),
     proxy: true,
     resave: false,

--- a/frontend/app/.server/opentelemetry.ts
+++ b/frontend/app/.server/opentelemetry.ts
@@ -7,7 +7,6 @@ import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
 import { ATTR_DEPLOYMENT_ENVIRONMENT_NAME } from '@opentelemetry/semantic-conventions/incubating';
-import { Redacted } from 'effect';
 
 import { serverEnvironment } from '~/.server/environment';
 import { LogFactory } from '~/.server/logging';
@@ -34,14 +33,14 @@ const nodeSdk = new NodeSDK({
     exporter: new OTLPMetricExporter({
       url: serverEnvironment.OTEL_METRICS_ENDPOINT,
       compression: CompressionAlgorithm.GZIP,
-      headers: { authorization: Redacted.value(serverEnvironment.OTEL_AUTH_HEADER) },
+      headers: { authorization: serverEnvironment.OTEL_AUTH_HEADER.value() },
     }),
   }),
 
   traceExporter: new OTLPTraceExporter({
     url: serverEnvironment.OTEL_TRACES_ENDPOINT,
     compression: CompressionAlgorithm.GZIP,
-    headers: { authorization: Redacted.value(serverEnvironment.OTEL_AUTH_HEADER) },
+    headers: { authorization: serverEnvironment.OTEL_AUTH_HEADER.value() },
   }),
 });
 

--- a/frontend/app/.server/redis.ts
+++ b/frontend/app/.server/redis.ts
@@ -1,4 +1,3 @@
-import { Duration, Redacted } from 'effect';
 import type { RedisOptions } from 'ioredis';
 import Redis from 'ioredis';
 
@@ -37,8 +36,8 @@ function getRedisConfig(): RedisOptions {
     REDIS_USERNAME,
   } = serverEnvironment;
 
-  const redisPassword = REDIS_PASSWORD && Redacted.value(REDIS_PASSWORD);
-  const redisCommandTimeout = Duration.toMillis(Duration.seconds(REDIS_COMMAND_TIMEOUT_SECONDS));
+  const redisPassword = REDIS_PASSWORD?.value();
+  const redisCommandTimeout = REDIS_COMMAND_TIMEOUT_SECONDS * 1000;
 
   const retryStrategy = (times: number): number => {
     // exponential backoff starting at 250ms to a maximum of 5s

--- a/frontend/app/.server/utils/security-utils.ts
+++ b/frontend/app/.server/utils/security-utils.ts
@@ -1,28 +1,19 @@
 /**
- * Represents a value that is redacted when stringified or logged.
- * @template T The type of the wrapped value
- */
-type Redacted<T> = RedactedContainer<T>;
-
-/**
- * Creates a new redacted value wrapper.
- *
- * @template T The type of the value to redact
- * @param value The value to wrap in a redacted container
- * @returns A redacted wrapper that hides the value when stringified
- */
-function createRedacted<T>(value: T): Redacted<T> {
-  return new RedactedContainer(value);
-}
-
-/**
  * A container class that wraps a value and ensures it is redacted when converted to a string or logged.
  * The original value can only be accessed through the explicit `value()` method.
  *
  * @template T The type of the encapsulated value
  */
-class RedactedContainer<T> {
+export class Redacted<T> {
   private readonly val: T;
+
+  /**
+   * Static factory function to make it easier to instantiate in lambda functions.
+   * @param value The value to wrap and redact
+   */
+  public static make<T>(value: T) {
+    return new Redacted(value);
+  }
 
   /**
    * Creates a new redacted container
@@ -70,24 +61,3 @@ class RedactedContainer<T> {
     return this.val;
   }
 }
-
-/**
- * A hybrid function-class that provides both a factory function for creating redacted values
- * and access to the RedactedContainer class itself.
- *
- * This can be used in two ways:
- *
- * 1. As a function to create redacted values:
- *    ```typescript
- *    const redacted = Redacted('sensitive data');
- *    ```
- *
- * 2. As a class:
- *    ```typescript
- *    const redacted = new Redacted('sensitive data')
- *    ```
- */
-export const Redacted: {
-  new <T>(value: T): Redacted<T>;
-  <T>(value: T): Redacted<T>;
-} = Object.assign(createRedacted, RedactedContainer);

--- a/frontend/app/.server/utils/security-utils.ts
+++ b/frontend/app/.server/utils/security-utils.ts
@@ -1,0 +1,93 @@
+/**
+ * Represents a value that is redacted when stringified or logged.
+ * @template T The type of the wrapped value
+ */
+type Redacted<T> = RedactedContainer<T>;
+
+/**
+ * Creates a new redacted value wrapper.
+ *
+ * @template T The type of the value to redact
+ * @param value The value to wrap in a redacted container
+ * @returns A redacted wrapper that hides the value when stringified
+ */
+function createRedacted<T>(value: T): Redacted<T> {
+  return new RedactedContainer(value);
+}
+
+/**
+ * A container class that wraps a value and ensures it is redacted when converted to a string or logged.
+ * The original value can only be accessed through the explicit `value()` method.
+ *
+ * @template T The type of the encapsulated value
+ */
+class RedactedContainer<T> {
+  private readonly val: T;
+
+  /**
+   * Creates a new redacted container
+   * @param value The value to wrap and redact
+   */
+  public constructor(value: T) {
+    this.val = value;
+  }
+
+  /**
+   * Custom inspection method for Node.js utilities like `util.inspect()`.
+   * This ensures the value appears redacted when using Node.js debugging tools.
+   * @see https://nodejs.org/api/util.html#utilinspectcustom
+   *
+   * @returns The value `'<redacted>'`
+   */
+  public [Symbol.for('nodejs.util.inspect.custom')](): '<redacted>' {
+    return this.toString();
+  }
+
+  /**
+   * Controls how the object is serialized when JSON.stringify() is called.
+   *
+   * @returns The value `'<redacted>'`
+   */
+  public toJSON(): '<redacted>' {
+    return this.toString();
+  }
+
+  /**
+   * Returns a redacted string representation that hides the actual value.
+   *
+   * @returns The value `'<redacted>'`
+   */
+  public toString(): '<redacted>' {
+    return '<redacted>';
+  }
+
+  /**
+   * Retrieves the original stored value.
+   *
+   * @returns The original value
+   */
+  public value(): T {
+    return this.val;
+  }
+}
+
+/**
+ * A hybrid function-class that provides both a factory function for creating redacted values
+ * and access to the RedactedContainer class itself.
+ *
+ * This can be used in two ways:
+ *
+ * 1. As a function to create redacted values:
+ *    ```typescript
+ *    const redacted = Redacted('sensitive data');
+ *    ```
+ *
+ * 2. As a class:
+ *    ```typescript
+ *    const redacted = new Redacted('sensitive data')
+ *    ```
+ */
+export const Redacted: {
+  new <T>(value: T): Redacted<T>;
+  <T>(value: T): Redacted<T>;
+} = Object.assign(createRedacted, RedactedContainer);

--- a/frontend/app/routes/api/health.ts
+++ b/frontend/app/routes/api/health.ts
@@ -1,6 +1,5 @@
 import type { HealthCheckOptions } from '@dts-stn/health-checks';
 import { execute } from '@dts-stn/health-checks';
-import { Redacted } from 'effect';
 
 import type { Route } from './+types/health';
 
@@ -58,8 +57,7 @@ async function isAuthorized(request: Request): Promise<boolean> {
   //
 
   const { AZUREAD_ISSUER_URL, AZUREAD_CLIENT_ID } = serverEnvironment;
-  const AZUREAD_CLIENT_SECRET =
-    serverEnvironment.AZUREAD_CLIENT_SECRET && Redacted.value(serverEnvironment.AZUREAD_CLIENT_SECRET);
+  const AZUREAD_CLIENT_SECRET = serverEnvironment.AZUREAD_CLIENT_SECRET?.value();
 
   if (!AZUREAD_ISSUER_URL || !AZUREAD_CLIENT_ID || !AZUREAD_CLIENT_SECRET) {
     throw new AppError('The Azure OIDC settings are misconfigured', ErrorCodes.MISCONFIGURED_PROVIDER);

--- a/frontend/app/routes/auth/callback.tsx
+++ b/frontend/app/routes/auth/callback.tsx
@@ -1,7 +1,5 @@
 import { redirect } from 'react-router';
 
-import { Redacted } from 'effect';
-
 import type { Route } from './+types/callback';
 
 import type { AuthenticationStrategy } from '~/.server/auth/auth-strategies';
@@ -30,8 +28,7 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
   switch (provider) {
     case 'azuread': {
       const { AZUREAD_ISSUER_URL, AZUREAD_CLIENT_ID } = serverEnvironment;
-      const AZUREAD_CLIENT_SECRET =
-        serverEnvironment.AZUREAD_CLIENT_SECRET && Redacted.value(serverEnvironment.AZUREAD_CLIENT_SECRET);
+      const AZUREAD_CLIENT_SECRET = serverEnvironment.AZUREAD_CLIENT_SECRET?.value();
 
       if (!AZUREAD_ISSUER_URL || !AZUREAD_CLIENT_ID || !AZUREAD_CLIENT_SECRET) {
         throw new AppError('The Azure OIDC settings are misconfigured', ErrorCodes.MISCONFIGURED_PROVIDER);

--- a/frontend/app/routes/auth/login.tsx
+++ b/frontend/app/routes/auth/login.tsx
@@ -1,7 +1,6 @@
 import { redirect } from 'react-router';
 
 import { trace } from '@opentelemetry/api';
-import { Redacted } from 'effect';
 
 import type { Route } from './+types/login';
 
@@ -37,8 +36,7 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
 
     case 'azuread': {
       const { AZUREAD_ISSUER_URL, AZUREAD_CLIENT_ID } = serverEnvironment;
-      const AZUREAD_CLIENT_SECRET =
-        serverEnvironment.AZUREAD_CLIENT_SECRET && Redacted.value(serverEnvironment.AZUREAD_CLIENT_SECRET);
+      const AZUREAD_CLIENT_SECRET = serverEnvironment.AZUREAD_CLIENT_SECRET?.value();
 
       if (!AZUREAD_ISSUER_URL || !AZUREAD_CLIENT_ID || !AZUREAD_CLIENT_SECRET) {
         throw new AppError('The Azure OIDC settings are misconfigured', ErrorCodes.MISCONFIGURED_PROVIDER);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,7 +31,6 @@
         "compression": "^1.8.0",
         "connect-redis": "^8.0.1",
         "cross-env": "^7.0.3",
-        "effect": "^3.13.2",
         "express": "^4.21.2",
         "express-session": "^1.18.1",
         "i": "^0.3.7",
@@ -4171,12 +4170,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
-      "license": "MIT"
-    },
     "node_modules/@tailwindcss/node": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.0.7.tgz",
@@ -6683,16 +6676,6 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
-    "node_modules/effect": {
-      "version": "3.13.2",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.13.2.tgz",
-      "integrity": "sha512-/w+CPqHDJ33Wq7xC4YKAchrEEPtjvxh563xH9kDTZp99seNYBoBs87vl8DJwartEjj+KLQLP8PzoDne+XmGT2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
-        "fast-check": "^3.23.1"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.102",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.102.tgz",
@@ -7715,28 +7698,6 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
-    },
-    "node_modules/fast-check": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
-      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/dubzzz"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fast-check"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "pure-rand": "^6.1.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -11407,22 +11368,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/pure-rand": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
-      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/dubzzz"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fast-check"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.13.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,7 +45,6 @@
     "compression": "^1.8.0",
     "connect-redis": "^8.0.1",
     "cross-env": "^7.0.3",
-    "effect": "^3.13.2",
     "express": "^4.21.2",
     "express-session": "^1.18.1",
     "i": "^0.3.7",

--- a/frontend/tests/.server/opentelemetry.test.ts
+++ b/frontend/tests/.server/opentelemetry.test.ts
@@ -16,10 +16,6 @@ vi.mock('@opentelemetry/auto-instrumentations-node');
 vi.mock('@opentelemetry/exporter-metrics-otlp-proto');
 vi.mock('@opentelemetry/exporter-trace-otlp-proto');
 
-vi.mock('effect', () => ({
-  Redacted: { value: vi.fn((val) => val) },
-}));
-
 vi.mock('~/.server/environment', () => ({
   serverEnvironment: {
     OTEL_SERVICE_NAME: 'service',
@@ -27,7 +23,7 @@ vi.mock('~/.server/environment', () => ({
     OTEL_ENVIRONMENT_NAME: 'test',
     OTEL_METRICS_ENDPOINT: 'http://metrics.example.com/',
     OTEL_TRACES_ENDPOINT: 'http://traces.example.com',
-    OTEL_AUTH_HEADER: 'Api-Key Sleep-Token',
+    OTEL_AUTH_HEADER: { value: () => 'Api-Key Sleep-Token' },
   },
 }));
 

--- a/frontend/tests/.server/redis.test.ts
+++ b/frontend/tests/.server/redis.test.ts
@@ -1,4 +1,3 @@
-import { Redacted } from 'effect';
 import Redis from 'ioredis';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -16,7 +15,7 @@ vi.mock('~/.server/environment', () => ({
     REDIS_CONNECTION_TYPE: undefined, // set in each test
     REDIS_HOST: 'localhost',
     REDIS_PORT: 6379,
-    REDIS_PASSWORD: Redacted.make('password'),
+    REDIS_PASSWORD: { value: () => 'password' },
     REDIS_USERNAME: 'user',
     REDIS_SENTINEL_MASTER_NAME: 'mymaster',
     REDIS_COMMAND_TIMEOUT_SECONDS: 10,

--- a/frontend/tests/.server/utils/security-utils.test.ts
+++ b/frontend/tests/.server/utils/security-utils.test.ts
@@ -5,8 +5,8 @@ import { Redacted } from '~/.server/utils/security-utils';
 
 describe('Redacted', () => {
   describe('constructor', () => {
-    it('can be constructed with function call', () => {
-      expect(Redacted('secret')).toBeDefined();
+    it('can be constructed with factory function call', () => {
+      expect(Redacted.make('secret')).toBeDefined();
     });
 
     it('can be constructed with new keyword', () => {
@@ -18,8 +18,8 @@ describe('Redacted', () => {
     it('should return <redacted> when JSON.stringify() is used', () => {
       expect(
         JSON.stringify({
-          secret: Redacted('secret'),
-          nested: { secret: Redacted('secret') },
+          secret: new Redacted('secret'),
+          nested: { secret: new Redacted('secret') },
         }),
       ).toEqual('{"secret":"<redacted>","nested":{"secret":"<redacted>"}}');
     });
@@ -27,24 +27,24 @@ describe('Redacted', () => {
 
   describe('toString', () => {
     it('should return <redacted> when toString() is called', () => {
-      expect(Redacted('secret').toString()).toEqual('<redacted>');
+      expect(new Redacted('secret').toString()).toEqual('<redacted>');
     });
 
     it('should return <redacted> when string interpolation is used', () => {
-      expect(`value is ${Redacted('secret')}`).toEqual('value is <redacted>');
+      expect(`value is ${new Redacted('secret')}`).toEqual('value is <redacted>');
     });
   });
 
   describe('value', () => {
     it('should return the original value when value() is called', () => {
       const original = { sensitive: 'data' };
-      expect(Redacted(original).value()).toEqual(original);
+      expect(new Redacted(original).value()).toEqual(original);
     });
   });
 
   describe('customInspectSymbol', () => {
     it('should return <redacted> when util.inspect() is called', () => {
-      expect(inspect(Redacted('secret'))).toEqual('<redacted>');
+      expect(inspect(new Redacted('secret'))).toEqual('<redacted>');
     });
   });
 });

--- a/frontend/tests/.server/utils/security-utils.test.ts
+++ b/frontend/tests/.server/utils/security-utils.test.ts
@@ -1,0 +1,50 @@
+import { inspect } from 'node:util';
+import { describe, expect, it } from 'vitest';
+
+import { Redacted } from '~/.server/utils/security-utils';
+
+describe('Redacted', () => {
+  describe('constructor', () => {
+    it('can be constructed with function call', () => {
+      expect(Redacted('secret')).toBeDefined();
+    });
+
+    it('can be constructed with new keyword', () => {
+      expect(new Redacted('secret')).toBeDefined();
+    });
+  });
+
+  describe('toJSON', () => {
+    it('should return <redacted> when JSON.stringify() is used', () => {
+      expect(
+        JSON.stringify({
+          secret: Redacted('secret'),
+          nested: { secret: Redacted('secret') },
+        }),
+      ).toEqual('{"secret":"<redacted>","nested":{"secret":"<redacted>"}}');
+    });
+  });
+
+  describe('toString', () => {
+    it('should return <redacted> when toString() is called', () => {
+      expect(Redacted('secret').toString()).toEqual('<redacted>');
+    });
+
+    it('should return <redacted> when string interpolation is used', () => {
+      expect(`value is ${Redacted('secret')}`).toEqual('value is <redacted>');
+    });
+  });
+
+  describe('value', () => {
+    it('should return the original value when value() is called', () => {
+      const original = { sensitive: 'data' };
+      expect(Redacted(original).value()).toEqual(original);
+    });
+  });
+
+  describe('customInspectSymbol', () => {
+    it('should return <redacted> when util.inspect() is called', () => {
+      expect(inspect(Redacted('secret'))).toEqual('<redacted>');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR introduces a new `Redacted()` callable class, inspired by [effect-ts's feature of the same name](https://effect.website/docs/data-types/redacted/).

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)
