### PR TITLE
bugfix(frontend): fix error on primary document screen when no date is provided

### DIFF
--- a/frontend/app/utils/date-utils.ts
+++ b/frontend/app/utils/date-utils.ts
@@ -240,6 +240,8 @@ export function getStartOfDayInTimezone(timezone: string, date?: number | string
  * @returns An ISO 8601 date string in the format "YYYY-MM-DD".
  */
 export function toISODateString(year: number, month: number, day: number): string {
+  if (isNaN(year) || isNaN(month) || isNaN(day)) return '';
+  if (!dateExists(year, month - 1, day)) return '';
   return formatISODate(`${year}-${month}-${day}`);
 }
 


### PR DESCRIPTION
## Summary

There is error when next button is click on primary document screen. The fields are hidden, and would be displayed depending on the selection. Since, there is no input for the date fields yet, the 'RangeError: Invalid time value\n' error is thrown by formatISO.

This pr fix the error, by providing empty string if the input isn't available yet. 

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
