### PR TITLE
feat(frontend): opentelemetry enhancements

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -123,6 +123,9 @@ REDIS_SENTINEL_MASTER_NAME=
 # Authenication configuration
 #################################################
 
+# Enable debug/diagnostics logging (default: false).
+OTEL_DEBUG=
+
 # The name of this service (default: Future SIR frontend).
 OTEL_SERVICE_NAME=
 
@@ -141,6 +144,11 @@ OTEL_METRICS_ENDPOINT=
 # URL to ship traces to (default: http://localhost:4318/v1/traces).
 OTEL_TRACES_ENDPOINT=
 
+# Enable the console metric exporter (default: false).
+OTEL_USE_CONSOLE_METRIC_EXPORTER=
+
+# Enable the console trace exporter (default: false)
+OTEL_USE_CONSOLE_TRACE_EXPORTER=
 
 
 #################################################

--- a/frontend/app/.server/environment/telemetry.ts
+++ b/frontend/app/.server/environment/telemetry.ts
@@ -1,23 +1,30 @@
 import * as v from 'valibot';
 
 import { Redacted } from '~/.server/utils/security-utils';
+import { stringToBooleanSchema } from '~/.server/validation/string-to-boolean-schema';
 
 export type Telemetry = Readonly<v.InferOutput<typeof telemetry>>;
 
 export const defaults = {
+  OTEL_DEBUG: 'false',
+  OTEL_AUTH_HEADER: 'Authorization 00000000-0000-0000-0000-000000000000',
+  OTEL_ENVIRONMENT_NAME: 'localhost',
+  OTEL_METRICS_ENDPOINT: 'http://localhost:4318/v1/metrics',
   OTEL_SERVICE_NAME: 'future-sir-frontend',
   OTEL_SERVICE_VERSION: '0.0.0',
-  OTEL_ENVIRONMENT_NAME: 'localhost',
-  OTEL_AUTH_HEADER: 'Authorization 00000000-0000-0000-0000-000000000000',
-  OTEL_METRICS_ENDPOINT: 'http://localhost:4318/v1/metrics',
   OTEL_TRACES_ENDPOINT: 'http://localhost:4318/v1/traces',
+  OTEL_USE_CONSOLE_METRIC_EXPORTER: 'false',
+  OTEL_USE_CONSOLE_TRACE_EXPORTER: 'false',
 } as const;
 
 export const telemetry = v.object({
+  OTEL_DEBUG: v.optional(stringToBooleanSchema(), defaults.OTEL_DEBUG),
+  OTEL_AUTH_HEADER: v.pipe(v.optional(v.string(), defaults.OTEL_AUTH_HEADER), v.transform(Redacted.make)),
+  OTEL_ENVIRONMENT_NAME: v.optional(v.string(), defaults.OTEL_ENVIRONMENT_NAME),
+  OTEL_METRICS_ENDPOINT: v.optional(v.string(), defaults.OTEL_METRICS_ENDPOINT),
   OTEL_SERVICE_NAME: v.optional(v.string(), defaults.OTEL_SERVICE_NAME),
   OTEL_SERVICE_VERSION: v.optional(v.string(), defaults.OTEL_SERVICE_VERSION),
-  OTEL_ENVIRONMENT_NAME: v.optional(v.string(), defaults.OTEL_ENVIRONMENT_NAME),
-  OTEL_AUTH_HEADER: v.pipe(v.optional(v.string(), defaults.OTEL_AUTH_HEADER), v.transform(Redacted.make)),
-  OTEL_METRICS_ENDPOINT: v.optional(v.string(), defaults.OTEL_METRICS_ENDPOINT),
   OTEL_TRACES_ENDPOINT: v.optional(v.string(), defaults.OTEL_TRACES_ENDPOINT),
+  OTEL_USE_CONSOLE_METRIC_EXPORTER: v.optional(stringToBooleanSchema(), defaults.OTEL_USE_CONSOLE_METRIC_EXPORTER),
+  OTEL_USE_CONSOLE_TRACE_EXPORTER: v.optional(stringToBooleanSchema(), defaults.OTEL_USE_CONSOLE_TRACE_EXPORTER),
 });

--- a/frontend/app/.server/opentelemetry.ts
+++ b/frontend/app/.server/opentelemetry.ts
@@ -1,10 +1,26 @@
+/*
+ * Initializes the OpenTelemetry SDK for the application.
+ *
+ * This file configures and starts the OpenTelemetry SDK to enable observability for the application.
+ * By default, it is configured to periodically emit metrics and traces to the endpoints
+ * specified in the server environment variables `OTEL_METRICS_ENDPOINT` and `OTEL_TRACES_ENDPOINT`.
+ *
+ * If these environment variables are not set, the SDK will attempt to send data to the default
+ * OpenTelemetry Collector endpoint, which is often http://localhost:4318/v1/metrics and
+ * http://localhost:4318/v1/traces for metrics and traces respectively.
+ *
+ * The service name, service version, and deployment environment are also configured using
+ * environment variables from `serverEnvironment`.
+ */
+import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-proto';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
 import { CompressionAlgorithm } from '@opentelemetry/otlp-exporter-base';
 import { Resource } from '@opentelemetry/resources';
-import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
+import { AggregationTemporality, ConsoleMetricExporter, PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
 import { NodeSDK } from '@opentelemetry/sdk-node';
+import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-node';
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
 import { ATTR_DEPLOYMENT_ENVIRONMENT_NAME } from '@opentelemetry/semantic-conventions/incubating';
 
@@ -14,6 +30,11 @@ import { LogFactory } from '~/.server/logging';
 const log = LogFactory.getLogger(import.meta.url);
 
 log.info('Initializing OpenTelemetry SDK...');
+
+if (serverEnvironment.OTEL_DEBUG) {
+  log.info('Enabling OpenTelemetry diagnostics logging');
+  diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ALL);
+}
 
 const nodeSdk = new NodeSDK({
   resource: new Resource({
@@ -30,19 +51,29 @@ const nodeSdk = new NodeSDK({
   ],
 
   metricReader: new PeriodicExportingMetricReader({
-    exporter: new OTLPMetricExporter({
-      url: serverEnvironment.OTEL_METRICS_ENDPOINT,
-      compression: CompressionAlgorithm.GZIP,
-      headers: { authorization: serverEnvironment.OTEL_AUTH_HEADER.value() },
-    }),
+    exporter: serverEnvironment.OTEL_USE_CONSOLE_METRIC_EXPORTER
+      ? new ConsoleMetricExporter()
+      : new OTLPMetricExporter({
+          url: serverEnvironment.OTEL_METRICS_ENDPOINT,
+          compression: CompressionAlgorithm.GZIP,
+          headers: { authorization: serverEnvironment.OTEL_AUTH_HEADER.value() },
+          temporalityPreference: AggregationTemporality.DELTA, // req'd by dynatrace
+        }),
   }),
 
-  traceExporter: new OTLPTraceExporter({
-    url: serverEnvironment.OTEL_TRACES_ENDPOINT,
-    compression: CompressionAlgorithm.GZIP,
-    headers: { authorization: serverEnvironment.OTEL_AUTH_HEADER.value() },
-  }),
+  traceExporter: serverEnvironment.OTEL_USE_CONSOLE_TRACE_EXPORTER
+    ? new ConsoleSpanExporter()
+    : new OTLPTraceExporter({
+        url: serverEnvironment.OTEL_TRACES_ENDPOINT,
+        compression: CompressionAlgorithm.GZIP,
+        headers: { authorization: serverEnvironment.OTEL_AUTH_HEADER.value() },
+      }),
 });
 
 log.info('OpenTelemetry SDK initialization complete; starting instrumentation');
 nodeSdk.start();
+
+process.on('SIGTERM', () => {
+  log.info('Shutting down OpenTelemetry SDK');
+  nodeSdk.shutdown().catch((error) => log.error('Error while shutting down OpenTelemetry SDK', error));
+});


### PR DESCRIPTION
## Summary

This PR adds a `createCounter()` function to `instrumentation-utils` and creates a `server.errors.total` counter in `entry.server.tsx` to keep track of server side errors.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [x] ensured metrics and/or tracing are in place for monitoring and debugging
- [x] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Screenshots

I intentionally threw a few errors locally and pushed the metrics to Dynatrace to generate this graph:

![image](https://github.com/user-attachments/assets/fb225c77-7f7c-4e6c-9a33-3f8b57f85a7a)
