### PR TITLE
add conditional rednering and beefed up validation to /contact-information

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -180,3 +180,5 @@ AZUREAD_CLIENT_SECRET=
 PP_ENGLISH_LANGUAGE_CODE=
 # Power Platform lanuage code for French type (default: 1036)
 PP_FRENCH_LANGUAGE_CODE=
+# Power Platform lanuage code for Canada Country Code (default: '0cf5389e-97ae-eb11-8236-000d3af4bfc3')
+PP_CANADA_COUNTRY_CODE=

--- a/frontend/app/.server/environment/power-platform.ts
+++ b/frontend/app/.server/environment/power-platform.ts
@@ -7,9 +7,11 @@ export type PowerPlatform = Readonly<v.InferOutput<typeof powerPlatform>>;
 export const defaults = {
   PP_ENGLISH_LANGUAGE_CODE: '1033',
   PP_FRENCH_LANGUAGE_CODE: '1036',
+  PP_CANADA_COUNTRY_CODE: '0cf5389e-97ae-eb11-8236-000d3af4bfc3',
 } as const;
 
 export const powerPlatform = v.object({
   PP_ENGLISH_LANGUAGE_CODE: v.optional(v.pipe(stringToIntegerSchema()), defaults.PP_ENGLISH_LANGUAGE_CODE),
   PP_FRENCH_LANGUAGE_CODE: v.optional(v.pipe(stringToIntegerSchema()), defaults.PP_FRENCH_LANGUAGE_CODE),
+  PP_CANADA_COUNTRY_CODE: v.optional(v.string(), defaults.PP_CANADA_COUNTRY_CODE),
 });

--- a/frontend/app/.server/locales/protected-en.json
+++ b/frontend/app/.server/locales/protected-en.json
@@ -240,7 +240,8 @@
     "address-help-message": "Include apartment number (if applicable), street number, street name. For example: 123 Main St. Suite 4B",
     "postal-code-label": "Postal code",
     "city-label": "City, town, or village",
-    "province-label": "Province, state, or region",
+    "canada-province-label": "Province or territory",
+    "other-country-province-label": "Province, state, or region",
     "error-messages": {
       "preferred-language-required": "Please select a preferred language",
       "primary-phone-required": "Please enter a primary phone number",

--- a/frontend/app/.server/locales/protected-fr.json
+++ b/frontend/app/.server/locales/protected-fr.json
@@ -241,7 +241,8 @@
     "address-help-message": "Include apartment number (if applicable), street number, street name. For example: 123 Main St. Suite 4B",
     "postal-code-label": "Postal code",
     "city-label": "City, town, or village",
-    "province-label": "Province, state, or region",
+    "canada-province-label": "Province or territory",
+    "other-country-province-label": "Province, state, or region",
     "error-messages": {
       "preferred-language-required": "Please select a preferred language",
       "primary-phone-required": "Please enter a primary phone number",

--- a/frontend/app/.server/services/locale-data-service.ts
+++ b/frontend/app/.server/services/locale-data-service.ts
@@ -29,32 +29,31 @@ export function getLocalizedCountries(locale: Language = 'en'): readonly Localiz
   }));
 }
 
-type ProvinceTerritoryState = Readonly<{
+type ProvinceTerritory = Readonly<{
   id: string;
-  countryId: string;
   nameEn: string;
   nameFr: string;
 }>;
 
-export function getProvincesTerritoriesStates(): readonly ProvinceTerritoryState[] {
-  return provinceTerritoryStateData.value.map((region) => ({
-    id: region.esdc_provinceterritorystateid,
-    countryId: region._esdc_countryid_value,
-    nameEn: region.esdc_nameenglish,
-    nameFr: region.esdc_namefrench,
-  }));
+export function getProvincesTerritories(): readonly ProvinceTerritory[] {
+  const { PP_CANADA_COUNTRY_CODE } = serverEnvironment;
+  return provinceTerritoryStateData.value
+    .filter((region) => region._esdc_countryid_value === PP_CANADA_COUNTRY_CODE)
+    .map((region) => ({
+      id: region.esdc_provinceterritorystateid,
+      nameEn: region.esdc_nameenglish,
+      nameFr: region.esdc_namefrench,
+    }));
 }
 
-type LocalizedProvinceTerritoryState = Readonly<{
+type LocalizedProvinceTerritory = Readonly<{
   id: string;
-  countryId: string;
   name: string;
 }>;
 
-export function getLocalizedProvincesTerritoriesStates(locale: Language = 'en'): readonly LocalizedProvinceTerritoryState[] {
-  return getProvincesTerritoriesStates().map((region) => ({
+export function getLocalizedProvincesTerritoriesStates(locale: Language = 'en'): readonly LocalizedProvinceTerritory[] {
+  return getProvincesTerritories().map((region) => ({
     id: region.id,
-    countryId: region.countryId,
     name: region[locale === 'en' ? 'nameEn' : 'nameFr'],
   }));
 }


### PR DESCRIPTION
## Summary
adds:
- conditional rendering to display province/territory select input if country select is Canada, otherwise display an input field for user to enter their province/territory/state
- beefed up validation to handle the case where Canada is selected (validates province/territory is valid)
- modifies `locale-data-service/ts` since we only consider Canadian provinces/territories, and not US states

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

