### PR TITLE
refactor(gitops): synchronize gitops frontend `config.conf` file

### DIFF
--- a/gitops/overlays/dev/configs/future-sir-frontend/config.conf
+++ b/gitops/overlays/dev/configs/future-sir-frontend/config.conf
@@ -13,9 +13,13 @@ LOG_LEVEL=debug
 # Specify the port used to serve the application.
 PORT=
 
-# Enables debug logging for the i18next localization library (default: false).
+# Enables debug logging for the i18next localization library (default: undefined).
 # Set to true to log additional information about translations and potential issues.
 I18NEXT_DEBUG=
+
+# The base timezone to use when performing date calculations (default: Canada/Eastern).
+# see: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+BASE_TIMEZONE=
 
 
 
@@ -81,6 +85,7 @@ SESSION_COOKIE_SECURE=
 SESSION_KEY_PREFIX=SESSION:DEV:
 
 
+
 #################################################
 # Redis configuration (used when SESSION_TYPE=redis)
 #################################################
@@ -116,10 +121,13 @@ REDIS_SENTINEL_MASTER_NAME=myprimary
 
 
 #################################################
-# Authenication configuration
+# OpenTelemetry configuration
 #################################################
 
-# The name of this service (default: Future SIR frontend).
+# Enable debug/diagnostics logging (default: false).
+OTEL_DEBUG=
+
+# The name of this service (default: future-sir-frontend).
 # OTEL_SERVICE_NAME=‼ set in container image at build time ‼
 
 # The version of this service (default: 0.0.0).
@@ -128,7 +136,9 @@ REDIS_SENTINEL_MASTER_NAME=myprimary
 # Name of the deployment environment (default: localhost).
 OTEL_ENVIRONMENT_NAME=dev
 
-# Autentication header name (default: Authorization 00000000-0000-0000-0000-000000000000).
+# Autentication header value (default: Authorization 00000000-0000-0000-0000-000000000000).
+# Enable this if the OpenTelemetry Collector requires an authentication header. For example,
+# Dynatrace requires an `Api-Token xxxxx` header.
 # OTEL_AUTH_HEADER=‼ set via k8s secret ‼
 
 # URL to ship metrics to (default: http://localhost:4318/v1/metrics).
@@ -136,6 +146,12 @@ OTEL_METRICS_ENDPOINT=https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b
 
 # URL to ship traces to (default: http://localhost:4318/v1/traces).
 OTEL_TRACES_ENDPOINT=https://dynatrace.dev-dp.admin.dts-stn.com/e/21a07aef-852b-4d9b-aa87-ee5f8b79f8c9/api/v2/otlp/v1/traces
+
+# Enable the console metric exporter (default: false).
+OTEL_USE_CONSOLE_METRIC_EXPORTER=
+
+# Enable the console trace exporter (default: false).
+OTEL_USE_CONSOLE_TRACE_EXPORTER=
 
 
 
@@ -166,3 +182,21 @@ AZUREAD_CLIENT_ID=fb240ef1-76a1-42a5-abcb-1d95ec0d6a0e
 # The Azure AD client secret.
 # This is used to authenticate your application with Azure AD.
 # AZUREAD_CLIENT_SECRET=‼ set via k8s secret ‼
+
+
+
+#################################################
+# Power Platform configuration
+#################################################
+
+# Power Platform lanuage code for `English` (default: 1033)
+# see app/.server/resources/preferred-language.json
+PP_ENGLISH_LANGUAGE_CODE=
+
+# Power Platform lanuage code for `French` (default: 1036)
+# see app/.server/resources/preferred-language.json
+PP_FRENCH_LANGUAGE_CODE=
+
+# Power Platform country code for `Canada` (default: '0cf5389e-97ae-eb11-8236-000d3af4bfc3')
+# see app/.server/resources/countries.json
+PP_CANADA_COUNTRY_CODE=


### PR DESCRIPTION
## Summary

This PR re-synchronizes the gitops `overlays/dev/configs/future-sir-frontend/config.conf` with the frontend's `.env.example` file so that we can more easily trace divergent changes.
