### PR TITLE
feat(eslint): restrict 'SessionData' import from 'react-router'

### DIFF
--- a/frontend/app/routes/protected/person-case/request-details.tsx
+++ b/frontend/app/routes/protected/person-case/request-details.tsx
@@ -1,8 +1,9 @@
 import { useId } from 'react';
 
-import type { RouteHandle, SessionData } from 'react-router';
+import type { RouteHandle } from 'react-router';
 import { data, useFetcher } from 'react-router';
 
+import type { SessionData } from 'express-session';
 import { useTranslation } from 'react-i18next';
 import * as v from 'valibot';
 
@@ -19,7 +20,7 @@ import { AppError } from '~/errors/app-error';
 import { getTranslation } from '~/i18n-config.server';
 import { handle as parentHandle } from '~/routes/protected/layout';
 
-type RequestDetailsSessionData = NonNullable<SessionData['inPersonSINCase']['privacyStatement']>;
+type RequestDetailsSessionData = NonNullable<SessionData['inPersonSINCase']['requestDetails']>;
 
 const VALID_REQUESTS = [
   'first-time',

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -76,6 +76,18 @@ export default tseslint.config(
       '@typescript-eslint/require-await': 'error',
       'import/consistent-type-specifier-style': ['error', 'prefer-top-level'],
       'no-param-reassign': 'error',
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'react-router',
+              importNames: ['SessionData'],
+              message: "Please use the SessionData import from 'express-session' instead.",
+            },
+          ],
+        },
+      ],
     },
     settings: {
       'import/resolver': {


### PR DESCRIPTION
## Summary

Enforced an [ESLint rule](https://eslint.org/docs/latest/rules/no-restricted-imports#importnames) to prevent importing `SessionData` from `react-router`, ensuring session management is handled via `express-session` for consistency and correctness.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)