### PR TITLE
load gender.json from PP and add locale service functions

### DIFF
--- a/frontend/app/.server/resources/genders.json
+++ b/frontend/app/.server/resources/genders.json
@@ -1,0 +1,177 @@
+{
+  "@odata.context": "https://canadadental-uat.crm3.dynamics.com/api/data/v9.2/$metadata#EntityDefinitions('esdc_demographic')/Attributes/Microsoft.Dynamics.CRM.PicklistAttributeMetadata(LogicalName,OptionSet(Options))",
+  "value": [
+    {
+      "@odata.type": "#Microsoft.Dynamics.CRM.PicklistAttributeMetadata",
+      "MetadataId": "5497ae1c-7ad6-ee11-904d-000d3a09d132",
+      "LogicalName": "esdc_gender",
+      "OptionSet": {
+        "MetadataId": "f4825710-7ad6-ee11-904d-000d3a09d132",
+        "Options": [
+          {
+            "Value": 775170000,
+            "Color": null,
+            "IsManaged": false,
+            "ExternalValue": "",
+            "ParentValues": [],
+            "Tag": null,
+            "IsHidden": false,
+            "MetadataId": null,
+            "HasChanged": null,
+            "Label": {
+              "LocalizedLabels": [
+                {
+                  "Label": "Male",
+                  "LanguageCode": 1033,
+                  "IsManaged": false,
+                  "MetadataId": "c52a3b2d-a4b5-407d-bb31-399f0c911f81",
+                  "HasChanged": null
+                },
+                {
+                  "Label": "Homme",
+                  "LanguageCode": 1036,
+                  "IsManaged": false,
+                  "MetadataId": "c52a3b2d-a4b5-407d-bb31-399f0c911f81",
+                  "HasChanged": null
+                }
+              ],
+              "UserLocalizedLabel": {
+                "Label": "Male",
+                "LanguageCode": 1033,
+                "IsManaged": false,
+                "MetadataId": "c52a3b2d-a4b5-407d-bb31-399f0c911f81",
+                "HasChanged": null
+              }
+            },
+            "Description": {
+              "LocalizedLabels": [
+                {
+                  "Label": "",
+                  "LanguageCode": 1033,
+                  "IsManaged": false,
+                  "MetadataId": "26b216be-b486-44ed-8cf0-8d6af0b4abf3",
+                  "HasChanged": null
+                }
+              ],
+              "UserLocalizedLabel": {
+                "Label": "",
+                "LanguageCode": 1033,
+                "IsManaged": false,
+                "MetadataId": "26b216be-b486-44ed-8cf0-8d6af0b4abf3",
+                "HasChanged": null
+              }
+            }
+          },
+          {
+            "Value": 775170001,
+            "Color": null,
+            "IsManaged": false,
+            "ExternalValue": "",
+            "ParentValues": [],
+            "Tag": null,
+            "IsHidden": false,
+            "MetadataId": null,
+            "HasChanged": null,
+            "Label": {
+              "LocalizedLabels": [
+                {
+                  "Label": "Female",
+                  "LanguageCode": 1033,
+                  "IsManaged": false,
+                  "MetadataId": "af0d0168-1fc3-4893-bb4d-c416e2607966",
+                  "HasChanged": null
+                },
+                {
+                  "Label": "Femme",
+                  "LanguageCode": 1036,
+                  "IsManaged": false,
+                  "MetadataId": "af0d0168-1fc3-4893-bb4d-c416e2607966",
+                  "HasChanged": null
+                }
+              ],
+              "UserLocalizedLabel": {
+                "Label": "Female",
+                "LanguageCode": 1033,
+                "IsManaged": false,
+                "MetadataId": "af0d0168-1fc3-4893-bb4d-c416e2607966",
+                "HasChanged": null
+              }
+            },
+            "Description": {
+              "LocalizedLabels": [
+                {
+                  "Label": "",
+                  "LanguageCode": 1033,
+                  "IsManaged": false,
+                  "MetadataId": "fc1cf6b9-afc8-4d57-9ca6-aec0a6bd4a33",
+                  "HasChanged": null
+                }
+              ],
+              "UserLocalizedLabel": {
+                "Label": "",
+                "LanguageCode": 1033,
+                "IsManaged": false,
+                "MetadataId": "fc1cf6b9-afc8-4d57-9ca6-aec0a6bd4a33",
+                "HasChanged": null
+              }
+            }
+          },
+          {
+            "Value": 775170002,
+            "Color": null,
+            "IsManaged": false,
+            "ExternalValue": "",
+            "ParentValues": [],
+            "Tag": null,
+            "IsHidden": false,
+            "MetadataId": null,
+            "HasChanged": null,
+            "Label": {
+              "LocalizedLabels": [
+                {
+                  "Label": "Other",
+                  "LanguageCode": 1033,
+                  "IsManaged": false,
+                  "MetadataId": "5e6d3772-b182-4a26-8cca-c0ce2152657e",
+                  "HasChanged": null
+                },
+                {
+                  "Label": "Autre",
+                  "LanguageCode": 1036,
+                  "IsManaged": false,
+                  "MetadataId": "5e6d3772-b182-4a26-8cca-c0ce2152657e",
+                  "HasChanged": null
+                }
+              ],
+              "UserLocalizedLabel": {
+                "Label": "Other",
+                "LanguageCode": 1033,
+                "IsManaged": false,
+                "MetadataId": "5e6d3772-b182-4a26-8cca-c0ce2152657e",
+                "HasChanged": null
+              }
+            },
+            "Description": {
+              "LocalizedLabels": [
+                {
+                  "Label": "",
+                  "LanguageCode": 1033,
+                  "IsManaged": false,
+                  "MetadataId": "59beb702-8b93-4a46-850b-27e9436457f7",
+                  "HasChanged": null
+                }
+              ],
+              "UserLocalizedLabel": {
+                "Label": "",
+                "LanguageCode": 1033,
+                "IsManaged": false,
+                "MetadataId": "59beb702-8b93-4a46-850b-27e9436457f7",
+                "HasChanged": null
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/frontend/app/.server/services/locale-data-service.ts
+++ b/frontend/app/.server/services/locale-data-service.ts
@@ -1,5 +1,6 @@
 import { serverEnvironment } from '~/.server/environment';
 import countryData from '~/.server/resources/countries.json';
+import genderData from '~/.server/resources/genders.json';
 import preferredLanguageData from '~/.server/resources/preferred-language.json';
 import provinceTerritoryStateData from '~/.server/resources/province-territory-state.json';
 
@@ -83,6 +84,36 @@ type LocalizedPreferredLanguage = Readonly<{
 
 export function getLocalizedPreferredLanguages(locale: Language = 'en'): LocalizedPreferredLanguage[] {
   return getPreferredLanguages().map((obj) => ({
+    id: obj.id,
+    name: obj[locale === 'en' ? 'nameEn' : 'nameFr'],
+  }));
+}
+
+type Gender = Readonly<{
+  id: string;
+  nameEn: string;
+  nameFr: string;
+}>;
+
+// TODO: throw AppError if `.find` fails?
+export function getGenders(): readonly Gender[] {
+  const { PP_ENGLISH_LANGUAGE_CODE, PP_FRENCH_LANGUAGE_CODE } = serverEnvironment;
+  return (
+    genderData.value.at(0)?.OptionSet.Options.map((obj) => ({
+      id: obj.Value.toString(),
+      nameEn: obj.Label.LocalizedLabels.find((lbl) => lbl.LanguageCode === PP_ENGLISH_LANGUAGE_CODE)?.Label ?? '',
+      nameFr: obj.Label.LocalizedLabels.find((lbl) => lbl.LanguageCode === PP_FRENCH_LANGUAGE_CODE)?.Label ?? '',
+    })) ?? []
+  );
+}
+
+export type LocalizedGender = Readonly<{
+  id: string;
+  name: string;
+}>;
+
+export function getLocalizedGenders(locale: Language = 'en'): LocalizedGender[] {
+  return getGenders().map((obj) => ({
     id: obj.id,
     name: obj[locale === 'en' ? 'nameEn' : 'nameFr'],
   }));


### PR DESCRIPTION
## Summary

Similar to previous PRs addressing adding PP data, this PR does the same for gender data and adds the implementation to `/primary-documents`.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>
