### PR TITLE
refactor(frontend): update date utils

### DIFF
--- a/frontend/app/routes/protected/person-case/primary-docs.tsx
+++ b/frontend/app/routes/protected/person-case/primary-docs.tsx
@@ -61,6 +61,14 @@ export function meta({ data }: Route.MetaArgs) {
   return [{ title: data.documentTitle }];
 }
 
+function toDateString(year: number, month: number, day: number): string {
+  try {
+    return toISODateString(year, month, day);
+  } catch {
+    return '';
+  }
+}
+
 export async function action({ context, request }: Route.ActionArgs) {
   requireAuth(context.session, new URL(request.url), ['user']);
 
@@ -218,12 +226,12 @@ export async function action({ context, request }: Route.ActionArgs) {
       const dateOfBirthYear = Number(formData.get('dateOfBirthYear'));
       const dateOfBirthMonth = Number(formData.get('dateOfBirthMonth'));
       const dateOfBirthDay = Number(formData.get('dateOfBirthDay'));
-      const dateOfBirth = toISODateString(dateOfBirthYear, dateOfBirthMonth, dateOfBirthDay);
+      const dateOfBirth = toDateString(dateOfBirthYear, dateOfBirthMonth, dateOfBirthDay);
 
       const citizenshipDateYear = Number(formData.get('citizenshipDateYear'));
       const citizenshipDateMonth = Number(formData.get('citizenshipDateMonth'));
       const citizenshipDateDay = Number(formData.get('citizenshipDateDay'));
-      const citizenshipDate = toISODateString(citizenshipDateYear, citizenshipDateMonth, citizenshipDateDay);
+      const citizenshipDate = toDateString(citizenshipDateYear, citizenshipDateMonth, citizenshipDateDay);
 
       const input = {
         currentStatusInCanada: String(formData.get('currentStatusInCanada')),

--- a/frontend/app/utils/date-utils.ts
+++ b/frontend/app/utils/date-utils.ts
@@ -241,8 +241,6 @@ export function getStartOfDayInTimezone(timezone: string, date?: number | string
  * @returns An ISO 8601 date string in the format "YYYY-MM-DD".
  */
 export function toISODateString(year: number, month: number, day: number): string {
-  if (isNaN(year) || isNaN(month) || isNaN(day)) return '';
-  if (!dateExists(year, month - 1, day)) return '';
   return formatISODate(`${year}-${month}-${day}`);
 }
 


### PR DESCRIPTION
The error is thrown when the next button is clicked on primary document screen, without selecting any option in the select field "Current status in Canada". 
Error Description: 'RangeError: Invalid time value\n' error is thrown by formatISO.

Updated the the date utils, so that the error thrown by the formatISO isn't masked. 
Updated the primary document screen, to handle the date of birth and certification date when these values are unavailable (because these fields are hidden).

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>
