### PR TITLE
update getLocalizedCountries to return a sorted array

### DIFF
--- a/frontend/app/.server/services/locale-data-service.ts
+++ b/frontend/app/.server/services/locale-data-service.ts
@@ -24,10 +24,18 @@ type LocalizedCountry = Readonly<{
 }>;
 
 export function getLocalizedCountries(locale: Language = 'en'): readonly LocalizedCountry[] {
-  return getCountries().map((country) => ({
+  const { PP_CANADA_COUNTRY_CODE } = serverEnvironment;
+  const countries = getCountries().map((country) => ({
     id: country.id,
     name: country[locale === 'en' ? 'nameEn' : 'nameFr'],
   }));
+  return countries
+    .filter((country) => country.id === PP_CANADA_COUNTRY_CODE)
+    .concat(
+      countries
+        .filter((country) => country.id !== PP_CANADA_COUNTRY_CODE)
+        .sort((a, b) => a.name.localeCompare(b.name, locale, { sensitivity: 'base' })),
+    );
 }
 
 type ProvinceTerritory = Readonly<{


### PR DESCRIPTION
## Summary

This PR ensures that when calling `getLocalizedCountries`, Canada is always the first element in the resultant array, followed by a localized sort of countries by name.  

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
