### PR TITLE
fix(frontend): match i18n routes containing path params

### DIFF
--- a/frontend/app/utils/route-utils.ts
+++ b/frontend/app/utils/route-utils.ts
@@ -1,3 +1,5 @@
+import { matchPath } from 'react-router';
+
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
 import type { I18nPageRoute, I18nRoute, I18nRouteFile } from '~/i18n-routes';
@@ -39,19 +41,13 @@ export function findRouteByPath(pathname: string, routes: I18nRoute[]): I18nPage
   for (const route of routes) {
     if (isI18nLayoutRoute(route)) {
       const matchingChildRoute = findRouteByPath(pathname, route.children);
-
-      if (matchingChildRoute) {
-        return matchingChildRoute;
-      }
+      if (matchingChildRoute) return matchingChildRoute;
     }
 
     if (isI18nPageRoute(route)) {
-      const enMatches = normalizedPathname === normalizePath(route.paths.en);
-      const frMatches = normalizedPathname === normalizePath(route.paths.fr);
-
-      if (enMatches || frMatches) {
-        return route;
-      }
+      const enMatches = matchPath(normalizePath(route.paths.en), normalizedPathname);
+      const frMatches = matchPath(normalizePath(route.paths.fr), normalizedPathname);
+      if (enMatches || frMatches) return route;
     }
   }
 }

--- a/frontend/tests/hooks/use-route.test.ts
+++ b/frontend/tests/hooks/use-route.test.ts
@@ -4,13 +4,20 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { useRoute } from '~/hooks/use-route';
 
-vi.mock('react-router', () => ({
-  useLocation: vi.fn(),
-}));
+vi.mock('react-router', async (importActual) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const actual = await importActual<typeof import('react-router')>();
+
+  return {
+    ...actual,
+    useLocation: vi.fn(),
+  };
+});
 
 describe('useRoute', () => {
   it('should return the correct route for a given pathname', () => {
     vi.mocked(useLocation, { partial: true }).mockReturnValue({ pathname: '/en/public' });
+
     expect(useRoute()).toEqual(
       expect.objectContaining({
         file: 'routes/public/index.tsx',


### PR DESCRIPTION
## Summary

This PR fixes a bug in `findRouteByPath()` that prevents routes with path parameters (ie: `/en/:id`) from being returned.

Once this PR is merged, I will submit a subsequent PR that updates the language switcher to retain path parameters during a language switch.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)
