### PR TITLE
fix(frontend): correctly propagate path params in `<LanguageSwitcher>`

### DIFF
--- a/frontend/app/components/language-switcher.tsx
+++ b/frontend/app/components/language-switcher.tsx
@@ -1,6 +1,6 @@
 import type { ComponentProps } from 'react';
 
-import { useLocation } from 'react-router';
+import { useLocation, useParams } from 'react-router';
 
 import { InlineLink } from '~/components/links';
 import { useLanguage } from '~/hooks/use-language';
@@ -8,18 +8,23 @@ import { useRoute } from '~/hooks/use-route';
 import type { I18nRouteFile } from '~/i18n-routes';
 import { cn } from '~/utils/tailwind-utils';
 
-type LanguageSwitcherProps = Omit<ComponentProps<typeof InlineLink>, 'file' | 'lang' | 'reloadDocument' | 'to'>;
+type LanguageSwitcherProps = OmitStrict<
+  ComponentProps<typeof InlineLink>,
+  'file' | 'lang' | 'params' | 'reloadDocument' | 'search' | 'to'
+>;
 
 export function LanguageSwitcher({ className, children, ...props }: LanguageSwitcherProps) {
   const { altLanguage } = useLanguage();
   const { search } = useLocation();
   const { file } = useRoute();
+  const params = useParams();
 
   return (
     <InlineLink
       className={cn('text-white hover:text-blue-100 focus:text-blue-200 sm:text-lg', className)}
       file={file as I18nRouteFile}
       lang={altLanguage}
+      params={params}
       reloadDocument={true}
       search={search}
       {...props}

--- a/frontend/tests/components/__snapshots__/language-switcher.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/language-switcher.test.tsx.snap
@@ -5,10 +5,10 @@ exports[`LanguageSwitcher > should render a LanguageSwitcher with the correct pr
   <a
     class="underline text-white hover:text-blue-100 focus:text-blue-200 sm:text-lg"
     data-discover="true"
-    href="/en/public"
-    lang="en"
+    href="/fr/00000000-0000-0000-0000-000000000000?foo=bar"
+    lang="fr"
   >
-    English
+    Français
   </a>
 </div>
 `;

--- a/frontend/tests/components/language-switcher.test.tsx
+++ b/frontend/tests/components/language-switcher.test.tsx
@@ -1,20 +1,37 @@
 import { createRoutesStub } from 'react-router';
 
 import { render } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { LanguageSwitcher } from '~/components/language-switcher';
+
+vi.mock('~/i18n-routes', async (importActual) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const actual = await importActual<typeof import('~/i18n-routes')>();
+
+  return {
+    ...actual,
+
+    i18nRoutes: [
+      {
+        id: 'ROUTE-0001',
+        file: 'routes/index.tsx',
+        paths: { en: '/en/:id', fr: '/fr/:id' },
+      },
+    ],
+  };
+});
 
 describe('LanguageSwitcher', () => {
   it('should render a LanguageSwitcher with the correct props', () => {
     const RoutesStub = createRoutesStub([
       {
-        path: '/fr/public',
-        Component: () => <LanguageSwitcher>English</LanguageSwitcher>,
+        path: '/en/:id',
+        Component: () => <LanguageSwitcher>Français</LanguageSwitcher>,
       },
     ]);
 
-    const { container } = render(<RoutesStub initialEntries={['/fr/public']} />);
+    const { container } = render(<RoutesStub initialEntries={['/en/00000000-0000-0000-0000-000000000000?foo=bar']} />);
     expect(container).toMatchSnapshot('expected html');
   });
 });


### PR DESCRIPTION
## Summary

Correctly handle path parameters when language switching. Prior to this PR, any path params (ex: the `id` in `/en/:id/foo`) would get discarded, leading to a 404.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>
