### PR TITLE
refactor province input in /birth-details

### DIFF
--- a/frontend/app/.server/services/locale-data-service.ts
+++ b/frontend/app/.server/services/locale-data-service.ts
@@ -61,10 +61,12 @@ type LocalizedProvinceTerritory = Readonly<{
 }>;
 
 export function getLocalizedProvincesTerritoriesStates(locale: Language = 'en'): readonly LocalizedProvinceTerritory[] {
-  return getProvincesTerritories().map((region) => ({
-    id: region.id,
-    name: region[locale === 'en' ? 'nameEn' : 'nameFr'],
-  }));
+  return getProvincesTerritories()
+    .map((region) => ({
+      id: region.id,
+      name: region[locale === 'en' ? 'nameEn' : 'nameFr'],
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name, locale, { sensitivity: 'base' }));
 }
 
 type PreferredLanguage = Readonly<{


### PR DESCRIPTION
## Summary
[AB#18177](https://dev.azure.com/ESDCCM/a4b4f7af-bbd7-4f0d-83ab-a123d0b70fda/_workitems/edit/18177)

Refactors `/birth-details` to use PP province data when the selected country of birth is Canada.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
