### PR TITLE
fix(frontend): bump ecmascript version on server to `ESNext`

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -29,7 +29,7 @@
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
-    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "noEmit": true,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,6 +14,9 @@ import { preserveImportMetaUrl } from './vite.server.config';
  * See vite.server.config.ts for the server build config.
  */
 export default defineConfig({
+  build: {
+    target: 'es2022',
+  },
   optimizeDeps: {
     entries: ['./app/entry.client.tsx', './app/root.tsx', './app/routes/**/*.tsx'],
   },


### PR DESCRIPTION
## Summary

This PR bumps the source version of ecmascript up to `ESNext` to allow developers to use the latest JS syntax in their code. See <https://developer.mozilla.org/en-US/docs/Web/JavaScript/JavaScript_technologies_overview>.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [x] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)
