### PR TITLE
feat(frontend): generate a browser tabid per flow

### DIFF
--- a/frontend/app/errors/error-codes.ts
+++ b/frontend/app/errors/error-codes.ts
@@ -13,6 +13,7 @@ export const ErrorCodes = {
   MISSING_LANG_PARAM: 'CMP-0001',
 
   // form error codes
+  MISSING_TAB_ID: 'FRM-0000',
   UNRECOGNIZED_ACTION: 'FRM-0001',
 
   // i18n error codes

--- a/frontend/app/i18n-routes.ts
+++ b/frontend/app/i18n-routes.ts
@@ -104,91 +104,105 @@ export const i18nRoutes = [
         paths: { en: '/en/protected/request', fr: '/fr/protege/requete' },
       },
       {
-        id: 'PROT-0004',
-        file: 'routes/protected/person-case/privacy-statement.tsx',
-        paths: {
-          en: '/en/protected/person-case/privacy-statement',
-          fr: '/fr/protege/cas-personnel/declaration-de-confidentialite',
-        },
-      },
-      {
-        id: 'PROT-0005',
-        file: 'routes/protected/person-case/primary-docs.tsx',
-        paths: { en: '/en/protected/person-case/primary-documents', fr: '/fr/protege/cas-personnel/documents-primaires' },
-      },
-      {
-        id: 'PROT-0006',
-        file: 'routes/protected/person-case/request-details.tsx',
-        paths: { en: '/en/protected/person-case/request-details', fr: '/fr/protege/cas-personnel/faire-une-demande' },
-      },
-      {
-        id: 'PROT-0007',
-        file: 'routes/protected/person-case/current-name.tsx',
-        paths: {
-          en: '/en/protected/person-case/current-name',
-          fr: '/fr/protege/cas-personnel/nom-actuel',
-        },
-      },
-      {
-        id: 'PROT-0008',
-        file: 'routes/protected/person-case/personal-info.tsx',
-        paths: {
-          en: '/en/protected/person-case/personal-information',
-          fr: '/fr/protege/cas-personnel/informations-personnelles',
-        },
-      },
-      {
-        id: 'PROT-0009',
-        file: 'routes/protected/person-case/secondary-doc.tsx',
-        paths: { en: '/en/protected/person-case/secondary-document', fr: '/fr/protege/cas-personnel/document-secondaire' },
-      },
-      {
-        id: 'PROT-0010',
-        file: 'routes/protected/person-case/birth-details.tsx',
-        paths: {
-          en: '/en/protected/person-case/birth-details',
-          fr: '/fr/protege/cas-personnel/details-de-naissance',
-        },
-      },
-      {
-        id: 'PROT-0011',
-        file: 'routes/protected/person-case/parent-details.tsx',
-        paths: {
-          en: '/en/protected/person-case/parent-details',
-          fr: '/fr/protege/cas-personnel/details-des-parents',
-        },
-      },
-      {
-        id: 'PROT-0012',
-        file: 'routes/protected/person-case/previous-sin.tsx',
-        paths: {
-          en: '/en/protected/person-case/previous-sin',
-          fr: '/fr/protege/cas-personnel/previous-sin',
-        },
-      },
-      {
-        id: 'PROT-0013',
-        file: 'routes/protected/person-case/contact-information.tsx',
-        paths: {
-          en: '/en/protected/person-case/contact-information',
-          fr: '/fr/protege/cas-personnel/contact-information',
-        },
-      },
-      {
-        id: 'PROT-0014',
-        file: 'routes/protected/person-case/review.tsx',
-        paths: {
-          en: '/en/protected/person-case/review',
-          fr: '/fr/protege/cas-personnel/revision',
-        },
-      },
-      {
-        id: 'PROT-0015',
-        file: 'routes/protected/person-case/search-sin.tsx',
-        paths: {
-          en: '/en/protected/person-case/search-sin',
-          fr: '/fr/protege/cas-personnel/search-sin',
-        },
+        file: 'routes/protected/person-case/layout.tsx',
+        children: [
+          {
+            id: 'PROT-0004',
+            file: 'routes/protected/person-case/privacy-statement.tsx',
+            paths: {
+              en: '/en/protected/person-case/privacy-statement',
+              fr: '/fr/protege/cas-personnel/declaration-de-confidentialite',
+            },
+          },
+          {
+            id: 'PROT-0005',
+            file: 'routes/protected/person-case/primary-docs.tsx',
+            paths: {
+              en: '/en/protected/person-case/primary-documents',
+              fr: '/fr/protege/cas-personnel/documents-primaires',
+            },
+          },
+          {
+            id: 'PROT-0006',
+            file: 'routes/protected/person-case/request-details.tsx',
+            paths: {
+              en: '/en/protected/person-case/request-details',
+              fr: '/fr/protege/cas-personnel/faire-une-demande',
+            },
+          },
+          {
+            id: 'PROT-0007',
+            file: 'routes/protected/person-case/current-name.tsx',
+            paths: {
+              en: '/en/protected/person-case/current-name',
+              fr: '/fr/protege/cas-personnel/nom-actuel',
+            },
+          },
+          {
+            id: 'PROT-0008',
+            file: 'routes/protected/person-case/personal-info.tsx',
+            paths: {
+              en: '/en/protected/person-case/personal-information',
+              fr: '/fr/protege/cas-personnel/informations-personnelles',
+            },
+          },
+          {
+            id: 'PROT-0009',
+            file: 'routes/protected/person-case/secondary-doc.tsx',
+            paths: {
+              en: '/en/protected/person-case/secondary-document',
+              fr: '/fr/protege/cas-personnel/document-secondaire',
+            },
+          },
+          {
+            id: 'PROT-0010',
+            file: 'routes/protected/person-case/birth-details.tsx',
+            paths: {
+              en: '/en/protected/person-case/birth-details',
+              fr: '/fr/protege/cas-personnel/details-de-naissance',
+            },
+          },
+          {
+            id: 'PROT-0011',
+            file: 'routes/protected/person-case/parent-details.tsx',
+            paths: {
+              en: '/en/protected/person-case/parent-details',
+              fr: '/fr/protege/cas-personnel/details-des-parents',
+            },
+          },
+          {
+            id: 'PROT-0012',
+            file: 'routes/protected/person-case/previous-sin.tsx',
+            paths: {
+              en: '/en/protected/person-case/previous-sin',
+              fr: '/fr/protege/cas-personnel/previous-sin',
+            },
+          },
+          {
+            id: 'PROT-0013',
+            file: 'routes/protected/person-case/contact-information.tsx',
+            paths: {
+              en: '/en/protected/person-case/contact-information',
+              fr: '/fr/protege/cas-personnel/contact-information',
+            },
+          },
+          {
+            id: 'PROT-0014',
+            file: 'routes/protected/person-case/review.tsx',
+            paths: {
+              en: '/en/protected/person-case/review',
+              fr: '/fr/protege/cas-personnel/revision',
+            },
+          },
+          {
+            id: 'PROT-0015',
+            file: 'routes/protected/person-case/search-sin.tsx',
+            paths: {
+              en: '/en/protected/person-case/search-sin',
+              fr: '/fr/protege/cas-personnel/search-sin',
+            },
+          },
+        ],
       },
       //
       // XState-driven in-person flow (poc)

--- a/frontend/app/routes/protected/person-case/birth-details.tsx
+++ b/frontend/app/routes/protected/person-case/birth-details.tsx
@@ -69,14 +69,21 @@ export function meta({ data }: Route.MetaArgs) {
 
 export async function action({ context, request }: Route.ActionArgs) {
   requireAuth(context.session, new URL(request.url), ['user']);
+
+  const tabId = new URL(request.url).searchParams.get('tid');
+  if (!tabId) throw new AppError('Missing tab id', ErrorCodes.MISSING_TAB_ID, { httpStatusCode: 400 });
+
   const { lang, t } = await getTranslation(request, handle.i18nNamespace);
+
   const { PP_CANADA_COUNTRY_CODE } = serverEnvironment;
   const formData = await request.formData();
   const action = formData.get('action');
 
   switch (action) {
     case 'back': {
-      throw i18nRedirect('routes/protected/person-case/personal-info.tsx', request);
+      throw i18nRedirect('routes/protected/person-case/personal-info.tsx', request, {
+        search: new URLSearchParams({ tid: tabId }),
+      });
     }
 
     case 'next': {
@@ -148,7 +155,10 @@ export async function action({ context, request }: Route.ActionArgs) {
       }
 
       (context.session.inPersonSINCase ??= {}).birthDetails = parseResult.output;
-      throw i18nRedirect('routes/protected/person-case/parent-details.tsx', request);
+
+      throw i18nRedirect('routes/protected/person-case/parent-details.tsx', request, {
+        search: new URLSearchParams({ tid: tabId }),
+      });
     }
 
     default: {

--- a/frontend/app/routes/protected/person-case/current-name.tsx
+++ b/frontend/app/routes/protected/person-case/current-name.tsx
@@ -74,6 +74,9 @@ export function meta({ data }: Route.MetaArgs) {
 export async function action({ context, request }: Route.ActionArgs) {
   requireAuth(context.session, new URL(request.url), ['user']);
 
+  const tabId = new URL(request.url).searchParams.get('tid');
+  if (!tabId) throw new AppError('Missing tab id', ErrorCodes.MISSING_TAB_ID, { httpStatusCode: 400 });
+
   const { lang, t } = await getTranslation(request, handle.i18nNamespace);
 
   const formData = await request.formData();
@@ -81,7 +84,9 @@ export async function action({ context, request }: Route.ActionArgs) {
 
   switch (action) {
     case 'back': {
-      throw i18nRedirect('routes/protected/person-case/secondary-doc.tsx', request);
+      throw i18nRedirect('routes/protected/person-case/secondary-doc.tsx', request, {
+        search: new URLSearchParams({ tid: tabId }),
+      });
     }
 
     case 'next': {
@@ -158,7 +163,10 @@ export async function action({ context, request }: Route.ActionArgs) {
       }
 
       (context.session.inPersonSINCase ??= {}).currentNameInfo = parseResult.output;
-      throw i18nRedirect('routes/protected/person-case/personal-info.tsx', request);
+
+      throw i18nRedirect('routes/protected/person-case/personal-info.tsx', request, {
+        search: new URLSearchParams({ tid: tabId }),
+      });
     }
 
     default: {

--- a/frontend/app/routes/protected/person-case/layout.tsx
+++ b/frontend/app/routes/protected/person-case/layout.tsx
@@ -1,0 +1,10 @@
+import { Outlet } from 'react-router';
+
+import type { Route } from './+types/layout';
+
+import { useTabId } from '~/hooks/use-tab-id';
+
+export default function Layout({ actionData, loaderData, matches, params }: Route.ComponentProps) {
+  const tabId = useTabId(); // ensure we always have a tabId generated
+  return <Outlet context={{ tabId }} />;
+}

--- a/frontend/app/routes/protected/person-case/parent-details.tsx
+++ b/frontend/app/routes/protected/person-case/parent-details.tsx
@@ -74,7 +74,11 @@ export function meta({ data }: Route.MetaArgs) {
 export async function action({ context, request }: Route.ActionArgs) {
   requireAuth(context.session, new URL(request.url), ['user']);
 
+  const tabId = new URL(request.url).searchParams.get('tid');
+  if (!tabId) throw new AppError('Missing tab id', ErrorCodes.MISSING_TAB_ID, { httpStatusCode: 400 });
+
   const { lang, t } = await getTranslation(request, handle.i18nNamespace);
+
   const { PP_CANADA_COUNTRY_CODE } = serverEnvironment;
   const formData = await request.formData();
   const action = formData.get('action');
@@ -82,7 +86,9 @@ export async function action({ context, request }: Route.ActionArgs) {
 
   switch (action) {
     case 'back': {
-      throw i18nRedirect('routes/protected/person-case/birth-details.tsx', request);
+      throw i18nRedirect('routes/protected/person-case/birth-details.tsx', request, {
+        search: new URLSearchParams({ tid: tabId }),
+      });
     }
 
     case 'next': {
@@ -190,7 +196,10 @@ export async function action({ context, request }: Route.ActionArgs) {
       }
 
       (context.session.inPersonSINCase ??= {}).parentDetails = parseResult.output;
-      throw i18nRedirect('routes/protected/person-case/previous-sin.tsx', request);
+
+      throw i18nRedirect('routes/protected/person-case/previous-sin.tsx', request, {
+        search: new URLSearchParams({ tid: tabId }),
+      });
     }
 
     default: {

--- a/frontend/app/routes/protected/person-case/personal-info.tsx
+++ b/frontend/app/routes/protected/person-case/personal-info.tsx
@@ -54,6 +54,10 @@ export function meta({ data }: Route.MetaArgs) {
 
 export async function action({ context, request }: Route.ActionArgs) {
   requireAuth(context.session, new URL(request.url), ['user']);
+
+  const tabId = new URL(request.url).searchParams.get('tid');
+  if (!tabId) throw new AppError('Missing tab id', ErrorCodes.MISSING_TAB_ID, { httpStatusCode: 400 });
+
   const { lang, t } = await getTranslation(request, handle.i18nNamespace);
 
   const formData = await request.formData();
@@ -62,7 +66,9 @@ export async function action({ context, request }: Route.ActionArgs) {
 
   switch (action) {
     case 'back': {
-      throw i18nRedirect('routes/protected/person-case/current-name.tsx', request);
+      throw i18nRedirect('routes/protected/person-case/current-name.tsx', request, {
+        search: new URLSearchParams({ tid: tabId }),
+      });
     }
 
     case 'next': {
@@ -99,7 +105,10 @@ export async function action({ context, request }: Route.ActionArgs) {
       }
 
       (context.session.inPersonSINCase ??= {}).personalInformation = parseResult.output;
-      throw i18nRedirect('routes/protected/person-case/birth-details.tsx', request);
+
+      throw i18nRedirect('routes/protected/person-case/birth-details.tsx', request, {
+        search: new URLSearchParams({ tid: tabId }),
+      });
     }
 
     default: {

--- a/frontend/app/routes/protected/person-case/previous-sin.tsx
+++ b/frontend/app/routes/protected/person-case/previous-sin.tsx
@@ -52,13 +52,19 @@ export function meta({ data }: Route.MetaArgs) {
 export async function action({ context, request }: Route.ActionArgs) {
   requireAuth(context.session, new URL(request.url), ['user']);
 
+  const tabId = new URL(request.url).searchParams.get('tid');
+  if (!tabId) throw new AppError('Missing tab id', ErrorCodes.MISSING_TAB_ID, { httpStatusCode: 400 });
+
   const { lang, t } = await getTranslation(request, handle.i18nNamespace);
+
   const formData = await request.formData();
   const action = formData.get('action');
 
   switch (action) {
     case 'back': {
-      throw i18nRedirect('routes/protected/person-case/parent-details.tsx', request);
+      throw i18nRedirect('routes/protected/person-case/parent-details.tsx', request, {
+        search: new URLSearchParams({ tid: tabId }),
+      });
     }
 
     case 'next': {
@@ -104,7 +110,10 @@ export async function action({ context, request }: Route.ActionArgs) {
       }
 
       (context.session.inPersonSINCase ??= {}).previousSin = parseResult.output;
-      throw i18nRedirect('routes/protected/person-case/contact-information.tsx', request);
+
+      throw i18nRedirect('routes/protected/person-case/contact-information.tsx', request, {
+        search: new URLSearchParams({ tid: tabId }),
+      });
     }
 
     default: {

--- a/frontend/app/routes/protected/person-case/primary-docs.tsx
+++ b/frontend/app/routes/protected/person-case/primary-docs.tsx
@@ -72,9 +72,14 @@ function toDateString(year: number, month: number, day: number): string {
 export async function action({ context, request }: Route.ActionArgs) {
   requireAuth(context.session, new URL(request.url), ['user']);
 
+  const tabId = new URL(request.url).searchParams.get('tid');
+  if (!tabId) throw new AppError('Missing tab id', ErrorCodes.MISSING_TAB_ID, { httpStatusCode: 400 });
+
   const { lang, t } = await getTranslation(request, handle.i18nNamespace);
+
   const formData = await request.formData();
   const action = formData.get('action');
+
   const nameMaxLength = 100;
   const registrationNumberLength = 8;
   const clientNumberLength = 10;
@@ -85,7 +90,9 @@ export async function action({ context, request }: Route.ActionArgs) {
 
   switch (action) {
     case 'back': {
-      throw i18nRedirect('routes/protected/person-case/request-details.tsx', request);
+      throw i18nRedirect('routes/protected/person-case/request-details.tsx', request, {
+        search: new URLSearchParams({ tid: tabId }),
+      });
     }
 
     case 'next': {
@@ -268,7 +275,9 @@ export async function action({ context, request }: Route.ActionArgs) {
 
       (context.session.inPersonSINCase ??= {}).primaryDocuments = parseResult.output;
 
-      throw i18nRedirect('routes/protected/person-case/secondary-doc.tsx', request);
+      throw i18nRedirect('routes/protected/person-case/secondary-doc.tsx', request, {
+        search: new URLSearchParams({ tid: tabId }),
+      });
     }
     default: {
       throw new AppError(`Unrecognized action: ${action}`, ErrorCodes.UNRECOGNIZED_ACTION);

--- a/frontend/app/routes/protected/person-case/privacy-statement.tsx
+++ b/frontend/app/routes/protected/person-case/privacy-statement.tsx
@@ -45,7 +45,11 @@ export function meta({ data }: Route.MetaArgs) {
 export async function action({ context, request }: Route.ActionArgs) {
   requireAuth(context.session, new URL(request.url), ['user']);
 
+  const tabId = new URL(request.url).searchParams.get('tid');
+  if (!tabId) throw new AppError('Missing tab id', ErrorCodes.MISSING_TAB_ID, { httpStatusCode: 400 });
+
   const { lang, t } = await getTranslation(request, handle.i18nNamespace);
+
   const formData = await request.formData();
   const action = formData.get('action');
 
@@ -70,7 +74,10 @@ export async function action({ context, request }: Route.ActionArgs) {
       }
 
       (context.session.inPersonSINCase ??= {}).privacyStatement = parseResult.output;
-      throw i18nRedirect('routes/protected/person-case/request-details.tsx', request);
+
+      throw i18nRedirect('routes/protected/person-case/request-details.tsx', request, {
+        search: new URLSearchParams({ tid: tabId }),
+      });
     }
 
     default: {

--- a/frontend/app/routes/protected/person-case/request-details.tsx
+++ b/frontend/app/routes/protected/person-case/request-details.tsx
@@ -62,13 +62,19 @@ export function meta({ data }: Route.MetaArgs) {
 export async function action({ context, request }: Route.ActionArgs) {
   requireAuth(context.session, new URL(request.url), ['user']);
 
+  const tabId = new URL(request.url).searchParams.get('tid');
+  if (!tabId) throw new AppError('Missing tab id', ErrorCodes.MISSING_TAB_ID, { httpStatusCode: 400 });
+
   const { lang, t } = await getTranslation(request, handle.i18nNamespace);
+
   const formData = await request.formData();
   const action = formData.get('action');
 
   switch (action) {
     case 'back': {
-      throw i18nRedirect('routes/protected/person-case/privacy-statement.tsx', request);
+      throw i18nRedirect('routes/protected/person-case/privacy-statement.tsx', request, {
+        search: new URLSearchParams({ tid: tabId }),
+      });
     }
 
     case 'next': {
@@ -89,7 +95,10 @@ export async function action({ context, request }: Route.ActionArgs) {
       }
 
       (context.session.inPersonSINCase ??= {}).requestDetails = parseResult.output;
-      throw i18nRedirect('routes/protected/person-case/primary-docs.tsx', request);
+
+      throw i18nRedirect('routes/protected/person-case/primary-docs.tsx', request, {
+        search: new URLSearchParams({ tid: tabId }),
+      });
     }
 
     default: {

--- a/frontend/app/routes/protected/person-case/review.tsx
+++ b/frontend/app/routes/protected/person-case/review.tsx
@@ -25,25 +25,27 @@ export const handle = {
 
 export async function loader({ context, request }: Route.LoaderArgs) {
   requireAuth(context.session, new URL(request.url), ['user']);
+
+  const tabId = new URL(request.url).searchParams.get('tid');
+  if (!tabId) throw new AppError('Missing tab id', ErrorCodes.MISSING_TAB_ID, { httpStatusCode: 400 });
+
   const { t } = await getTranslation(request, handle.i18nNamespace);
-  const inPersonSINCase = validateInPersonSINCaseSession(context.session, request);
-  return { documentTitle: t('protected:review.page-title'), inPersonSINCase };
+  const inPersonSINCase = validateInPersonSINCaseSession(context.session, tabId, request);
+
+  return { documentTitle: t('protected:review.page-title'), inPersonSINCase, tabId };
 }
 
-/**
- *
- * @param session
- * @param request
- * @returns
- */
 function validateInPersonSINCaseSession(
   session: AppSession,
+  tabId: string,
   request: Request,
 ): Required<NonNullable<SessionData['inPersonSINCase']>> {
   const inPersonSINCase = session.inPersonSINCase;
 
   if (inPersonSINCase === undefined) {
-    throw i18nRedirect('routes/protected/person-case/privacy-statement.tsx', request);
+    throw i18nRedirect('routes/protected/person-case/privacy-statement.tsx', request, {
+      search: new URLSearchParams({ tid: tabId }),
+    });
   }
 
   const {
@@ -60,43 +62,63 @@ function validateInPersonSINCaseSession(
   } = inPersonSINCase;
 
   if (privacyStatement === undefined) {
-    throw i18nRedirect('routes/protected/index.tsx', request);
+    throw i18nRedirect('routes/protected/index.tsx', request, {
+      search: new URLSearchParams({ tid: tabId }),
+    });
   }
 
   if (requestDetails === undefined) {
-    throw i18nRedirect('routes/protected/person-case/request-details.tsx', request);
+    throw i18nRedirect('routes/protected/person-case/request-details.tsx', request, {
+      search: new URLSearchParams({ tid: tabId }),
+    });
   }
 
   if (primaryDocuments === undefined) {
-    throw i18nRedirect('routes/protected/person-case/primary-docs.tsx', request);
+    throw i18nRedirect('routes/protected/person-case/primary-docs.tsx', request, {
+      search: new URLSearchParams({ tid: tabId }),
+    });
   }
 
   if (secondaryDocument === undefined) {
-    throw i18nRedirect('routes/protected/person-case/secondary-doc.tsx', request);
+    throw i18nRedirect('routes/protected/person-case/secondary-doc.tsx', request, {
+      search: new URLSearchParams({ tid: tabId }),
+    });
   }
 
   if (currentNameInfo === undefined) {
-    throw i18nRedirect('routes/protected/person-case/current-name.tsx', request);
+    throw i18nRedirect('routes/protected/person-case/current-name.tsx', request, {
+      search: new URLSearchParams({ tid: tabId }),
+    });
   }
 
   if (personalInformation === undefined) {
-    throw i18nRedirect('routes/protected/person-case/personal-info.tsx', request);
+    throw i18nRedirect('routes/protected/person-case/personal-info.tsx', request, {
+      search: new URLSearchParams({ tid: tabId }),
+    });
   }
 
   if (birthDetails === undefined) {
-    throw i18nRedirect('routes/protected/person-case/birth-details.tsx', request);
+    throw i18nRedirect('routes/protected/person-case/birth-details.tsx', request, {
+      search: new URLSearchParams({ tid: tabId }),
+    });
   }
 
   if (parentDetails === undefined) {
-    throw i18nRedirect('routes/protected/person-case/parent-details.tsx', request);
+    throw i18nRedirect('routes/protected/person-case/parent-details.tsx', request, {
+      search: new URLSearchParams({ tid: tabId }),
+    });
   }
 
   if (previousSin === undefined) {
-    throw i18nRedirect('routes/protected/person-case/previous-sin.tsx', request);
+    throw i18nRedirect('routes/protected/person-case/previous-sin.tsx', request, {
+      search: new URLSearchParams({ tid: tabId }),
+    });
   }
 
   if (contactInformation === undefined) {
-    throw i18nRedirect('routes/protected/person-case/contact-information.tsx', request);
+    throw i18nRedirect('routes/protected/person-case/contact-information.tsx', request, {
+      search: new URLSearchParams({ tid: tabId }),
+    });
   }
 
   return {
@@ -119,14 +141,17 @@ export function meta({ data }: Route.MetaArgs) {
 
 export async function action({ context, request }: Route.ActionArgs) {
   requireAuth(context.session, new URL(request.url), ['user']);
-  // const inPersonSINCase = validateInPersonSINCaseSession(context.session, request);
+  const tabId = new URL(request.url).searchParams.get('tid');
+  if (!tabId) throw new AppError('Missing tab id', ErrorCodes.MISSING_TAB_ID, { httpStatusCode: 400 });
 
   const formData = await request.formData();
   const action = formData.get('action');
 
   switch (action) {
     case 'back': {
-      throw i18nRedirect('routes/protected/person-case/contact-information.tsx', request);
+      throw i18nRedirect('routes/protected/person-case/contact-information.tsx', request, {
+        search: new URLSearchParams({ tid: tabId }),
+      });
     }
 
     case 'next': {
@@ -196,7 +221,12 @@ export default function Review({ loaderData, actionData, params }: Route.Compone
                   <p>{t('protected:review.choosen-file')}</p>
                 </DescriptionListItem>
               </DescriptionList>
-              <ButtonLink file="routes/protected/person-case/primary-docs.tsx" variant="link" size="lg">
+              <ButtonLink
+                file="routes/protected/person-case/primary-docs.tsx"
+                variant="link"
+                size="lg"
+                search={`tid=${loaderData.tabId}`}
+              >
                 {t('protected:review.edit-primary-identity-document')}
               </ButtonLink>
             </section>

--- a/frontend/app/routes/protected/person-case/search-sin.tsx
+++ b/frontend/app/routes/protected/person-case/search-sin.tsx
@@ -11,6 +11,8 @@ import { requireAuth } from '~/.server/utils/auth-utils';
 import { Button } from '~/components/button';
 import { FetcherErrorSummary } from '~/components/error-summary';
 import { PageTitle } from '~/components/page-title';
+import { AppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
 import { getTranslation } from '~/i18n-config.server';
 import { handle as parentHandle } from '~/routes/protected/layout';
 
@@ -20,6 +22,7 @@ export const handle = {
 
 export async function loader({ context, request }: Route.LoaderArgs) {
   requireAuth(context.session, new URL(request.url), ['user']);
+
   const { t } = await getTranslation(request, handle.i18nNamespace);
 
   //TODO: fetch and return session data (names, dob, etc)
@@ -34,6 +37,9 @@ export function meta({ data }: Route.MetaArgs) {
 
 export function action({ context, request }: Route.ActionArgs) {
   requireAuth(context.session, new URL(request.url), ['user']);
+
+  const tabId = new URL(request.url).searchParams.get('tid');
+  if (!tabId) throw new AppError('Missing tab id', ErrorCodes.MISSING_TAB_ID, { httpStatusCode: 400 });
 
   //TODO: fetch and return mock table result data
 }


### PR DESCRIPTION
## Summary

This PR lays the groundwork for a state machine managing the in-person application flows by introducing `tabId` tracking. This feature will eventually allow users to initiate and complete multiple flows concurrently in separate browser tabs without session data conflicts.

## Problem

Currently, session data is shared across all browser tabs, which prevents users from completing multiple in-person application flows concurrently.

## Solution

To allow users to complete multiple in-person application flows concurrently, we need a way to isolate the data that is stored in session for each browser tab. The best way to handle this is to leverage the browser's built-in session store feature to store a unique id, which is then added to all requests in the flow.

## Changes in this PR

- Ensure the `tabId` is propagated throughout the relevant parts of the in-person case flow.

# Future work

This PR is a prerequisite for future work implementing tab-specific session data management and the state machine. Subsequent PRs will:

* Utilize the `tabId` to isolate session data.
* Introduce a state machine to manage the flow of the in-person application.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)
