### PR TITLE
feat(frontend): add personal details and birth details on review page

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -197,6 +197,6 @@ PP_ENGLISH_LANGUAGE_CODE=
 # see app/.server/resources/preferred-language.json
 PP_FRENCH_LANGUAGE_CODE=
 
-# Power Platform country code for `Canada` (default: '0cf5389e-97ae-eb11-8236-000d3af4bfc3')
+# Power Platform country code for `Canada` (default: 'f8914e7c-2c95-ea11-a812-000d3a0c2b5d')
 # see app/.server/resources/countries.json
 PP_CANADA_COUNTRY_CODE=

--- a/frontend/app/.server/environment/power-platform.ts
+++ b/frontend/app/.server/environment/power-platform.ts
@@ -7,7 +7,7 @@ export type PowerPlatform = Readonly<v.InferOutput<typeof powerPlatform>>;
 export const defaults = {
   PP_ENGLISH_LANGUAGE_CODE: '1033',
   PP_FRENCH_LANGUAGE_CODE: '1036',
-  PP_CANADA_COUNTRY_CODE: '0cf5389e-97ae-eb11-8236-000d3af4bfc3',
+  PP_CANADA_COUNTRY_CODE: 'f8914e7c-2c95-ea11-a812-000d3a0c2b5d',
 } as const;
 
 export const powerPlatform = v.object({

--- a/frontend/app/.server/locales/protected-en.json
+++ b/frontend/app/.server/locales/protected-en.json
@@ -400,9 +400,13 @@
     "choosen-file": "File_chosen.pdf",
     "yes": "Yes",
     "no": "No",
+    "birth-place": "Birth place",
+    "multiple-birth": "Multiple birth",
     "edit-primary-identity-document": "Edit primary identity document",
     "edit-secondary-identity-document": "Edit secondary identity document",
-    "edit-current-name": "Edit current name"
+    "edit-current-name": "Edit current name",
+    "edit-personal-details": "Edit personal details",
+    "edit-birth-details": "Edit birth details"
   },
   "search-sin": {
     "page-title": "Search for a SIN",

--- a/frontend/app/.server/locales/protected-fr.json
+++ b/frontend/app/.server/locales/protected-fr.json
@@ -401,9 +401,13 @@
     "choosen-file": "Fichier_choisi.pdf",
     "yes": "Oui",
     "no": "Non",
+    "birth-place": "Lieu de naissance",
+    "multiple-birth": "Naissance multiple",
     "edit-primary-identity-document": "Modifier le document d'identité principal",
     "edit-secondary-identity-document": "Modifier le document d'identité secondaire",
-    "edit-current-name": "Modifier le nom actuel"
+    "edit-current-name": "Modifier le nom actuel",
+    "edit-personal-details": "Modifier les détails personnels",
+    "edit-birth-details": "Modifier les détails de naissance"
   },
   "search-sin": {
     "page-title": "Search for a SIN",

--- a/frontend/app/routes/protected/person-case/birth-details.tsx
+++ b/frontend/app/routes/protected/person-case/birth-details.tsx
@@ -45,7 +45,7 @@ export async function loader({ context, request }: Route.LoaderArgs) {
   const birthDetails = context.session.inPersonSINCase?.birthDetails;
 
   return {
-    documentTitle: t('protected:primary-identity-document.page-title'),
+    documentTitle: t('protected:birth-details.page-title'),
     localizedCountries: countryService.getLocalizedCountries(lang),
     localizedProvincesTerritoriesStates: provinceService.getLocalizedProvinces(lang),
     PP_CANADA_COUNTRY_CODE,


### PR DESCRIPTION

[AB#14685](https://dev.azure.com/ESDCCM/a4b4f7af-bbd7-4f0d-83ab-a123d0b70fda/_workitems/edit/14685)
---- Add personal detail and birth detail on review screen
updated country code to match IDs from PP

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/cb01b131-ece9-4084-b0b4-9ef01d9cd90e)
