### PR TITLE
feat(frontend): add details for parents, sin and contact information on review page

### DIFF
--- a/frontend/app/.server/locales/protected-en.json
+++ b/frontend/app/.server/locales/protected-en.json
@@ -349,7 +349,10 @@
     "edit-secondary-identity-document": "Edit secondary identity document",
     "edit-current-name": "Edit current name",
     "edit-personal-details": "Edit personal details",
-    "edit-birth-details": "Edit birth details"
+    "edit-birth-details": "Edit birth details",
+    "edit-parent-details": "Edit parent details",
+    "edit-previous-sin": "Edit previous sin",
+    "edit-contact-information": "Edit contact information"
   },
   "search-sin": {
     "page-title": "Search for a SIN",

--- a/frontend/app/.server/locales/protected-fr.json
+++ b/frontend/app/.server/locales/protected-fr.json
@@ -350,7 +350,10 @@
     "edit-secondary-identity-document": "Modifier le document d'identité secondaire",
     "edit-current-name": "Modifier le nom actuel",
     "edit-personal-details": "Modifier les détails personnels",
-    "edit-birth-details": "Modifier les détails de naissance"
+    "edit-birth-details": "Modifier les détails de naissance",
+    "edit-parent-details": "Modifier les détails des parents",
+    "edit-previous-sin": "Modifier les NAS précédent",
+    "edit-contact-information": "Modifier les informations de contact"
   },
   "search-sin": {
     "page-title": "Search for a SIN",

--- a/frontend/app/components/address.tsx
+++ b/frontend/app/components/address.tsx
@@ -1,0 +1,33 @@
+import type { ComponentProps } from 'react';
+
+import { formatAddress } from '~/utils/string-utils';
+import { cn } from '~/utils/tailwind-utils';
+
+export interface AddressDetails {
+  addressLine1?: string;
+  addressLine2?: string;
+  city?: string;
+  country: string;
+  postalZipCode?: string;
+  provinceState?: string;
+}
+
+export interface AddressProps extends ComponentProps<'address'> {
+  address: AddressDetails;
+  /**
+   * The format of the address
+   *
+   * - `standard`: The standard address format, with the address line, city, province/state, postal/zip code, and country.
+   * - `alternative`: An alternative address format, with the address line, city, province/state, postal/zip code, and country on separate lines.
+   */
+  format?: 'standard' | 'alternative';
+}
+
+export function Address({ address, format = 'standard', className, ...restProps }: AddressProps) {
+  const formattedAddress = formatAddress({ ...address, format });
+  return (
+    <address className={cn('whitespace-pre-wrap not-italic', className)} data-testid="address-id" {...restProps}>
+      {formattedAddress}
+    </address>
+  );
+}

--- a/frontend/app/components/address.tsx
+++ b/frontend/app/components/address.tsx
@@ -1,19 +1,19 @@
-import type { ComponentProps } from 'react';
+import type { ComponentProps, JSX } from 'react';
 
 import { formatAddress } from '~/utils/string-utils';
 import { cn } from '~/utils/tailwind-utils';
 
-export interface AddressDetails {
+type Address = {
   addressLine1?: string;
   addressLine2?: string;
   city?: string;
-  country: string;
   postalZipCode?: string;
   provinceState?: string;
-}
+  country: string;
+};
 
-export interface AddressProps extends ComponentProps<'address'> {
-  address: AddressDetails;
+type AddressProps = ComponentProps<'address'> & {
+  address: Address;
   /**
    * The format of the address
    *
@@ -21,13 +21,12 @@ export interface AddressProps extends ComponentProps<'address'> {
    * - `alternative`: An alternative address format, with the address line, city, province/state, postal/zip code, and country on separate lines.
    */
   format?: 'standard' | 'alternative';
-}
+};
 
-export function Address({ address, format = 'standard', className, ...restProps }: AddressProps) {
-  const formattedAddress = formatAddress({ ...address, format });
+export function Address({ address, format, className, ...rest }: AddressProps): JSX.Element {
   return (
-    <address className={cn('whitespace-pre-wrap not-italic', className)} data-testid="address-id" {...restProps}>
-      {formattedAddress}
+    <address className={cn('whitespace-pre-wrap not-italic', className)} data-testid="address-id" {...rest}>
+      {formatAddress(address, format)}
     </address>
   );
 }

--- a/frontend/app/routes/protected/person-case/review.tsx
+++ b/frontend/app/routes/protected/person-case/review.tsx
@@ -438,9 +438,9 @@ function PersonalDetailsData({ data, tabId }: PersonalDetailsDataProps) {
         <DescriptionListItem term={t('protected:personal-information.first-name-previously-used.label')}>
           {data.firstNamePreviouslyUsed && data.firstNamePreviouslyUsed.length > 0 && (
             <ul className="ml-6 list-disc">
-              {data.firstNamePreviouslyUsed.map(
-                (value, index) => value.length > 0 && <li key={`${index}-${value}`}>{value}</li>,
-              )}
+              {data.firstNamePreviouslyUsed.map((value, index) => (
+                <li key={`${index}-${value}`}>{value}</li>
+              ))}
             </ul>
           )}
         </DescriptionListItem>
@@ -450,9 +450,9 @@ function PersonalDetailsData({ data, tabId }: PersonalDetailsDataProps) {
         <DescriptionListItem term={t('protected:personal-information.last-name-previously-used.label')}>
           {data.lastNamePreviouslyUsed && data.lastNamePreviouslyUsed.length > 0 && (
             <ul className="ml-6 list-disc">
-              {data.lastNamePreviouslyUsed.map(
-                (value, index) => value.length > 0 && <li key={`${index}-${value}`}>{value}</li>,
-              )}
+              {data.lastNamePreviouslyUsed.map((value, index) => (
+                <li key={`${index}-${value}`}>{value}</li>
+              ))}
             </ul>
           )}
         </DescriptionListItem>

--- a/frontend/app/utils/string-utils.ts
+++ b/frontend/app/utils/string-utils.ts
@@ -37,3 +37,140 @@ export function padWithZero(value: number, maxLength: number): string {
 export function trimToUndefined(str: string | undefined): string | undefined {
   return Number(str?.trim().length) > 0 ? str : undefined;
 }
+
+/**
+ * Arguments for formatting just the address line
+ */
+interface FormatAddressLineArguments {
+  /** Street name and house number */
+  addressLine1: string;
+  /** Apartment, suite, or unit number */
+  addressLine2?: string;
+}
+
+/**
+ * Formats an apartment/suite number with the address
+ * @param params Address line formatting parameters
+ * @returns Formatted address line
+ */
+function formatAddressLine({ addressLine1, addressLine2 }: FormatAddressLineArguments): string {
+  if (!addressLine2?.trim()) {
+    return addressLine1;
+  }
+
+  // Check if addressLine2 is a simple alphanumeric suite number
+  const isSuiteNumber = /^[a-z\d]+$/i.test(addressLine2.trim());
+
+  return isSuiteNumber ? `${addressLine2.trim()}-${addressLine1}` : `${addressLine1} ${addressLine2.trim()}`;
+}
+
+/**
+ * Arguments for formatting a complete address
+ */
+export interface FormatAddressArguments {
+  /** Street name and house number (optional) */
+  addressLine1?: string;
+
+  /** City name */
+  city?: string;
+
+  /** Country name */
+  country: string;
+
+  /** Province or state code (optional) */
+  provinceState?: string;
+
+  /** Postal or ZIP code (optional) */
+  postalZipCode?: string;
+
+  /** Apartment, suite, or unit number (optional) */
+  addressLine2?: string;
+
+  /**
+   * The format of the address
+   *
+   * - `standard`: The standard address format, with the address line, city, province/state, postal/zip code, and country.
+   * - `alternative`: An alternative address format, with the address line, city, province/state, postal/zip code, and country on separate lines.
+   */
+  format?: 'standard' | 'alternative';
+}
+
+/**
+ * Formats an address string based on the provided arguments.
+ *
+ * @param params Address formatting parameters
+ * @returns Formatted address string
+ *
+ * @example
+ * ``` typescript
+ * const address1 = {
+ * addressLine1: '123 Main St',
+ * city: 'Anytown',
+ * country: 'Canada',
+ * provinceState: 'ON',
+ * postalZipCode: 'A1A 1A1',
+ * addressLine2: 'Apt 4B',
+ * };
+ *
+ * const address2 = {
+ * addressLine1: '456 Oak Ave',
+ * city: 'Springfield',
+ * country: 'Canada',
+ * postalZipCode: 'A1A 1A1',
+ * };
+ *
+ * const address3 = {
+ * addressLine1: '789 Pine Ln',
+ * city: 'London',
+ * country: 'UK',
+ * format: 'alternative',
+ * };
+ *
+ * console.log(formatAddress(address1));
+ * // Apt 4B-123 Main St
+ * // Anytown ON  A1A 1A1
+ * // Canada
+ *
+ * console.log(formatAddress(address2));
+ * // 456 Oak Ave
+ * // Springfield A1A 1A1
+ * // Canada
+ *
+ * console.log(formatAddress(address3));
+ * // 789 Pine Ln
+ * // London
+ * // UK
+ * ```
+ */
+export function formatAddress({
+  addressLine1,
+  city,
+  country,
+  provinceState,
+  postalZipCode,
+  addressLine2,
+  format = 'standard',
+}: FormatAddressArguments): string {
+  const formattedAddressLine = addressLine1 ? formatAddressLine({ addressLine1, addressLine2 }) : addressLine2;
+
+  const lines =
+    format === 'alternative'
+      ? [
+          formattedAddressLine && `${formattedAddressLine}`,
+          [city && `${city}`, provinceState && `, ${provinceState}`].filter(Boolean).join(''),
+          postalZipCode,
+          country,
+        ]
+      : [
+          formattedAddressLine && `${formattedAddressLine}`,
+          [city && `${city}`, provinceState && ` ${provinceState}`, postalZipCode && `  ${postalZipCode}`]
+            .filter(Boolean)
+            .join(''),
+          country,
+        ];
+
+  return lines
+    .map((line) => line?.trim())
+    .filter(Boolean)
+    .join('\n');
+}

--- a/frontend/app/utils/string-utils.ts
+++ b/frontend/app/utils/string-utils.ts
@@ -39,133 +39,117 @@ export function trimToUndefined(str: string | undefined): string | undefined {
 }
 
 /**
- * Arguments for formatting just the address line
- */
-interface FormatAddressLineArguments {
-  /** Street name and house number */
-  addressLine1: string;
-  /** Apartment, suite, or unit number */
-  addressLine2?: string;
-}
-
-/**
  * Formats an apartment/suite number with the address
- * @param params Address line formatting parameters
- * @returns Formatted address line
+ * TODO ::: GjB ::: I think this should be moved into the <Address> component
  */
-function formatAddressLine({ addressLine1, addressLine2 }: FormatAddressLineArguments): string {
-  if (!addressLine2?.trim()) {
-    return addressLine1;
-  }
+function formatAddressLine(addressLine1: string | undefined, addressLine2: string | undefined): string | undefined {
+  if (!addressLine1?.trim()) return addressLine2;
+  if (!addressLine2?.trim()) return addressLine1;
 
-  // Check if addressLine2 is a simple alphanumeric suite number
+  // check if addressLine2 is a simple alphanumeric suite number
   const isSuiteNumber = /^[a-z\d]+$/i.test(addressLine2.trim());
 
-  return isSuiteNumber ? `${addressLine2.trim()}-${addressLine1}` : `${addressLine1} ${addressLine2.trim()}`;
+  return isSuiteNumber
+    ? `${addressLine2.trim()}-${addressLine1.trim()}` //
+    : `${addressLine1.trim()} ${addressLine2.trim()}`;
 }
 
 /**
- * Arguments for formatting a complete address
+ * TODO ::: GjB ::: I think this should be moved into the <Address> component
  */
-export interface FormatAddressArguments {
-  /** Street name and house number (optional) */
-  addressLine1?: string;
-
-  /** City name */
-  city?: string;
-
-  /** Country name */
-  country: string;
-
-  /** Province or state code (optional) */
-  provinceState?: string;
-
-  /** Postal or ZIP code (optional) */
-  postalZipCode?: string;
-
-  /** Apartment, suite, or unit number (optional) */
-  addressLine2?: string;
-
+type Address = {
   /**
-   * The format of the address
-   *
-   * - `standard`: The standard address format, with the address line, city, province/state, postal/zip code, and country.
-   * - `alternative`: An alternative address format, with the address line, city, province/state, postal/zip code, and country on separate lines.
+   * Street name and house number
    */
-  format?: 'standard' | 'alternative';
-}
+  addressLine1?: string;
+  /**
+   * City name
+   */
+  city?: string;
+  /**
+   * Country name
+   */
+  country: string;
+  /**
+   * Province or state code
+   */
+  provinceState?: string;
+  /**
+   * Postal or ZIP code (optional)
+   */
+  postalZipCode?: string;
+  /**
+   * Apartment, suite, or unit number
+   */
+  addressLine2?: string;
+};
 
 /**
  * Formats an address string based on the provided arguments.
+ * TODO ::: GjB ::: I think this should be moved into the <Address> component
  *
- * @param params Address formatting parameters
+ * @param address - the address to be formatted
+ * @param format - the format to use, where:
+ *   - `standard`: The standard address format, with the address line, city, province/state, postal/zip code, and country.
+ *   - `alternative`: An alternative address format, with the address line, city, province/state, postal/zip code, and country on separate lines.
  * @returns Formatted address string
  *
  * @example
  * ``` typescript
- * const address1 = {
- * addressLine1: '123 Main St',
- * city: 'Anytown',
- * country: 'Canada',
- * provinceState: 'ON',
- * postalZipCode: 'A1A 1A1',
- * addressLine2: 'Apt 4B',
- * };
+ * formatAddress({
+ *   addressLine1: '123 Main St',
+ *   addressLine2: 'Apt 4B',
+ *   city: 'Anytown',
+ *   provinceState: 'ON',
+ *   postalZipCode: 'A1A 1A1',
+ *   country: 'Canada',
+ * });
  *
- * const address2 = {
- * addressLine1: '456 Oak Ave',
- * city: 'Springfield',
- * country: 'Canada',
- * postalZipCode: 'A1A 1A1',
- * };
- *
- * const address3 = {
- * addressLine1: '789 Pine Ln',
- * city: 'London',
- * country: 'UK',
- * format: 'alternative',
- * };
- *
- * console.log(formatAddress(address1));
  * // Apt 4B-123 Main St
  * // Anytown ON  A1A 1A1
  * // Canada
+ * ```
+ * @example
+ * ``` typescript
+ * formatAddress({
+ *   addressLine1: '456 Oak Ave',
+ *   city: 'Springfield',
+ *   postalZipCode: 'A1A 1A1',
+ *   country: 'Canada',
+ * });
  *
- * console.log(formatAddress(address2));
  * // 456 Oak Ave
  * // Springfield A1A 1A1
  * // Canada
+ * ```
+ * @example
+ * ``` typescript
+ * formatAddress({
+ *   format: 'alternative',
+ *   addressLine1: '789 Pine Ln',
+ *   city: 'London',
+ *   country: 'UK',
+ * });
  *
- * console.log(formatAddress(address3));
  * // 789 Pine Ln
  * // London
  * // UK
  * ```
  */
-export function formatAddress({
-  addressLine1,
-  city,
-  country,
-  provinceState,
-  postalZipCode,
-  addressLine2,
-  format = 'standard',
-}: FormatAddressArguments): string {
-  const formattedAddressLine = addressLine1 ? formatAddressLine({ addressLine1, addressLine2 }) : addressLine2;
+export function formatAddress(address: Address, format?: 'standard' | 'alternative'): string {
+  const { addressLine1, addressLine2, city, provinceState, postalZipCode, country } = address;
 
   const lines =
     format === 'alternative'
       ? [
-          formattedAddressLine && `${formattedAddressLine}`,
-          [city && `${city}`, provinceState && `, ${provinceState}`].filter(Boolean).join(''),
+          formatAddressLine(addressLine1, addressLine2),
+          [city, provinceState].filter(Boolean).join(', '),
           postalZipCode,
           country,
         ]
       : [
-          formattedAddressLine && `${formattedAddressLine}`,
-          [city && `${city}`, provinceState && ` ${provinceState}`, postalZipCode && `  ${postalZipCode}`]
-            .filter(Boolean)
-            .join(''),
+          formatAddressLine(addressLine1, addressLine2),
+          [city, provinceState, postalZipCode].filter(Boolean).join(' '),
           country,
         ];
 

--- a/frontend/tests/utils/string-utils.test.ts
+++ b/frontend/tests/utils/string-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { randomString } from '~/utils/string-utils';
+import { formatAddress, randomString } from '~/utils/string-utils';
 
 describe('string-utils', () => {
   describe('randomString', () => {
@@ -14,6 +14,126 @@ describe('string-utils', () => {
       const str = randomString(128, 'Future SIR');
       expect(str.length).toEqual(128);
       expect(str).toMatch(/[Future SIR]+/);
+    });
+  });
+
+  describe('formatAddress', () => {
+    it('should format a standard address with all fields', () => {
+      const result = formatAddress({
+        addressLine1: 'Apt 4B',
+        addressLine2: '123 Main St',
+        city: 'Anytown',
+        provinceState: 'ON',
+        postalZipCode: 'A1A 1A1',
+        country: 'Canada',
+      });
+
+      expect(result).toEqual('Apt 4B 123 Main St\nAnytown ON A1A 1A1\nCanada');
+    });
+
+    it('should format a standard address without addressLine2', () => {
+      const result = formatAddress({
+        addressLine1: '123 Main St',
+        city: 'Anytown',
+        provinceState: 'ON',
+        postalZipCode: 'A1A 1A1',
+        country: 'Canada',
+      });
+
+      expect(result).toEqual('123 Main St\nAnytown ON A1A 1A1\nCanada');
+    });
+
+    it('should format a standard address with all fields, simple addressLine2', () => {
+      const result = formatAddress({
+        addressLine1: '123 Main St',
+        addressLine2: '4B',
+        city: 'Anytown',
+        provinceState: 'ON',
+        postalZipCode: 'A1A 1A1',
+        country: 'Canada',
+      });
+
+      expect(result).toEqual('4B-123 Main St\nAnytown ON A1A 1A1\nCanada');
+    });
+
+    it('should format a standard address without provinceState and postalZipCode', () => {
+      const result = formatAddress({
+        addressLine1: '789 Pine Ln',
+        city: 'London',
+        country: 'UK',
+      });
+
+      expect(result).toEqual('789 Pine Ln\nLondon\nUK');
+    });
+
+    it('should format an alternative address with all fields', () => {
+      const result = formatAddress(
+        {
+          addressLine1: '123 Main St',
+          addressLine2: 'Apt 4B',
+          city: 'Anytown',
+          provinceState: 'ON',
+          postalZipCode: 'A1A 1A1',
+          country: 'Canada',
+        },
+        'alternative',
+      );
+
+      expect(result).toEqual('123 Main St Apt 4B\nAnytown, ON\nA1A 1A1\nCanada');
+    });
+
+    it('should format an alternative address without provinceState and postalZipCode', () => {
+      const result = formatAddress(
+        {
+          addressLine1: '789 Pine Ln',
+          city: 'London',
+          country: 'UK',
+        },
+        'alternative',
+      );
+
+      expect(result).toEqual('789 Pine Ln\nLondon\nUK');
+    });
+
+    it('should handle empty addressLine1 and addressLine2', () => {
+      const result = formatAddress({
+        city: 'London',
+        country: 'UK',
+      });
+
+      expect(result).toEqual('London\nUK');
+    });
+
+    it('should handle empty addressLine1, addressLine2, and city', () => {
+      const result = formatAddress({
+        country: 'UK',
+      });
+
+      expect(result).toEqual('UK');
+    });
+
+    it('should handle empty provinceState', () => {
+      const result = formatAddress({
+        addressLine1: '123 Main St',
+        city: 'Anytown',
+        postalZipCode: 'A1A 1A1',
+        country: 'Canada',
+      });
+
+      expect(result).toEqual('123 Main St\nAnytown A1A 1A1\nCanada');
+    });
+
+    it('should format a standard address with complex suite name', () => {
+      const result = formatAddress({
+        addressLine1: '123 Main St',
+        addressLine2: 'Suite 4B',
+        city: 'Anytown',
+        provinceState: 'ON',
+        postalZipCode: 'A1A 1A1',
+        country: 'Canada',
+      });
+
+      expect(result).toEqual('123 Main St Suite 4B\nAnytown ON A1A 1A1\nCanada');
     });
   });
 });


### PR DESCRIPTION
## Summary
[AB#14685](https://dev.azure.com/ESDCCM/a4b4f7af-bbd7-4f0d-83ab-a123d0b70fda/_workitems/edit/14685)
Add details for parents, sin and contact information on review page

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Screenshots
Information for parents is available on review screen:
![image](https://github.com/user-attachments/assets/c76627d6-b1e2-4bd8-bbc7-188503965a8d)

Parents information is unavailable, Previous sin and contact information on review screen:
![image](https://github.com/user-attachments/assets/870e804e-53eb-46d0-a9f5-dcaaab86e5eb)

