### PR TITLE
fix(frontend): remove deprecated package

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -71,7 +71,6 @@
         "@testing-library/react": "^16.2.0",
         "@trivago/prettier-plugin-sort-imports": "^5.2.2",
         "@types/compression": "^1.7.5",
-        "@types/eslint__eslintrc": "^3.3.0",
         "@types/eslint-plugin-jsx-a11y": "^6.10.0",
         "@types/express-session": "^1.18.1",
         "@types/jmespath": "^0.15.2",
@@ -4687,17 +4686,6 @@
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint__eslintrc": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@types/eslint__eslintrc/-/eslint__eslintrc-3.3.0.tgz",
-      "integrity": "sha512-u9C5PHo8zhLBTEpWAV1YsP3ijj3GjM+4r2aGLbkT+vqtBubwgSI8KiRHXtC2QcxDGR0qM3Qapg7OtTB58JmoYQ==",
-      "deprecated": "This is a stub types definition. @eslint/eslintrc provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint/eslintrc": "*"
       }
     },
     "node_modules/@types/eslint-plugin-jsx-a11y": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -86,7 +86,6 @@
     "@testing-library/react": "^16.2.0",
     "@trivago/prettier-plugin-sort-imports": "^5.2.2",
     "@types/compression": "^1.7.5",
-    "@types/eslint__eslintrc": "^3.3.0",
     "@types/eslint-plugin-jsx-a11y": "^6.10.0",
     "@types/express-session": "^1.18.1",
     "@types/jmespath": "^0.15.2",


### PR DESCRIPTION
## Summary

Fixing the following warning that appeared after merging #318:

```
npm warn deprecated @types/eslint__eslintrc@3.3.0: This is a stub types definition. @eslint/eslintrc provides its own type definitions, so you do not need this installed.
```

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [x] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>
