### PR TITLE
update(frontend): fix the personal detail screen to display primary doc screen data

### DIFF
--- a/frontend/app/routes/protected/person-case/personal-info.tsx
+++ b/frontend/app/routes/protected/person-case/personal-info.tsx
@@ -38,6 +38,10 @@ export async function loader({ context, request }: Route.LoaderArgs) {
 
   return {
     documentTitle: t('protected:personal-information.page-title'),
+    primaryDocValues: {
+      lastName: context.session.inPersonSINCase?.primaryDocuments?.lastName,
+      gender: context.session.inPersonSINCase?.primaryDocuments?.gender,
+    },
     defaultFormValues: {
       firstNamePreviouslyUsed: context.session.inPersonSINCase?.personalInformation?.firstNamePreviouslyUsed ?? [],
       lastNameAtBirth: context.session.inPersonSINCase?.personalInformation?.lastNameAtBirth,
@@ -131,10 +135,12 @@ export default function PersonalInformation({ loaderData, params }: Route.Compon
   const [lastNames, setLastNames] = useState(loaderData.defaultFormValues.lastNamePreviouslyUsed);
   const [srAnnouncement, setSrAnnouncement] = useState('');
 
+  const genderId = loaderData.defaultFormValues.gender ?? loaderData.primaryDocValues.gender;
+
   const genderOptions = loaderData.localizedGenders.map(({ id, name }) => ({
     value: id,
     children: name,
-    defaultChecked: id === loaderData.defaultFormValues.gender,
+    defaultChecked: id === genderId,
   }));
 
   function handleAddFirstName() {
@@ -223,7 +229,7 @@ export default function PersonalInformation({ loaderData, params }: Route.Compon
             </div>
             <InputField
               id="last-name-at-birth-id"
-              defaultValue={loaderData.defaultFormValues.lastNameAtBirth}
+              defaultValue={loaderData.defaultFormValues.lastNameAtBirth ?? loaderData.primaryDocValues.lastName}
               errorMessage={errors?.lastNameAtBirth?.at(0)}
               label={t('protected:personal-information.last-name-at-birth.label')}
               name="lastNameAtBirth"


### PR DESCRIPTION
[AB#16170](https://dev.azure.com/ESDCCM/FSIR/_workitems/edit/16170)
Display the default values for last name at birth and gender on the personal detail screen from primary doc screen data

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>
