### PR TITLE
feat(frontend): in-person browser tab isolation

### DIFF
--- a/frontend/app/routes/protected/person-case/@types.d.ts
+++ b/frontend/app/routes/protected/person-case/@types.d.ts
@@ -2,94 +2,101 @@ import 'express-session';
 
 import type { ServerEnvironment } from '~/.server/environment';
 
+export type BirthDetailsData =
+  | { country: ServerEnvironment['PP_CANADA_COUNTRY_CODE']; province: string; city: string; fromMultipleBirth: boolean }
+  | { country: string; province?: string; city?: string; fromMultipleBirth: boolean };
+
+export type ContactInformationData = {
+  preferredLanguage: string;
+  primaryPhoneNumber: string;
+  secondaryPhoneNumber?: string;
+  emailAddress?: string;
+  country: string;
+  address: string;
+  postalCode: string;
+  city: string;
+  province: string;
+};
+
+export type CurrentNameData =
+  | { preferredSameAsDocumentName: true }
+  | {
+      preferredSameAsDocumentName: false;
+      firstName: string;
+      middleName?: string;
+      lastName: string;
+      supportingDocuments:
+        | { required: false } //
+        | { required: true; documentTypes: string[] };
+    };
+
+export type ParentDetailsData = (
+  | { unavailable: true }
+  | {
+      unavailable: false;
+      givenName: string;
+      lastName: string;
+      birthLocation:
+        | { country: 'CAN'; province: string; city: string } //
+        | { country: string; province?: string; city?: string };
+    }
+)[];
+
+export type PersonalInfoData = {
+  firstNamePreviouslyUsed?: string[];
+  lastNameAtBirth: string;
+  lastNamePreviouslyUsed?: string[];
+  gender: string;
+};
+
+export type PreviousSinData = {
+  hasPreviousSin: string;
+  socialInsuranceNumber?: string;
+};
+
+export type PrimaryDocumentData = {
+  citizenshipDate: string;
+  clientNumber: string;
+  currentStatusInCanada: string;
+  dateOfBirth: string;
+  documentType: string;
+  gender: string;
+  givenName: string;
+  lastName: string;
+  registrationNumber: string;
+};
+
+export type PrivacyStatementData = {
+  agreedToTerms: true;
+};
+
+export type RequestDetailsData = {
+  type: string;
+  scenario: string;
+};
+
+export type SecondaryDocumentData = {
+  documentType: string;
+  // document: File; TODO :: enable me!
+  expiryDate: string;
+};
+
+export type InPersonSinApplication = Partial<{
+  currentNameInfo: CurrentNameData;
+  privacyStatement: PrivacyStatementData;
+  requestDetails: RequestDetailsData;
+  primaryDocuments: PrimaryDocumentData;
+  personalInformation: PersonalInfoData;
+  secondaryDocument: SecondaryDocumentData;
+  previousSin: PreviousSinData;
+  contactInformation: ContactInformationData;
+  birthDetails: BirthDetailsData;
+  parentDetails: ParentDetailsData;
+}>;
+
 declare module 'express-session' {
   interface SessionData {
-    inPersonSINCase: Partial<{
-      currentNameInfo:
-        | { preferredSameAsDocumentName: true }
-        | {
-            preferredSameAsDocumentName: false;
-            firstName: string;
-            middleName?: string;
-            lastName: string;
-            supportingDocuments:
-              | { required: false } //
-              | { required: true; documentTypes: string[] };
-          };
-      privacyStatement: {
-        agreedToTerms: true;
-      };
-      requestDetails: {
-        type: string;
-        scenario: string;
-      };
-      primaryDocuments: {
-        citizenshipDate: string;
-        clientNumber: string;
-        currentStatusInCanada: string;
-        dateOfBirth: string;
-        documentType: string;
-        gender: string;
-        givenName: string;
-        lastName: string;
-        registrationNumber: string;
-        /*
-        TODO: Enable file upload
-        document: File;
-        */
-      };
-      personalInformation: {
-        firstNamePreviouslyUsed?: string[];
-        lastNameAtBirth: string;
-        lastNamePreviouslyUsed?: string[];
-        gender: string;
-      };
-      secondaryDocument: {
-        documentType: string;
-        /*
-        TODO: Enable file upload
-        document: File;
-        */
-        expiryDate: string;
-      };
-      previousSin: {
-        hasPreviousSin: string;
-        socialInsuranceNumber?: string;
-      };
-      contactInformation: {
-        preferredLanguage: string;
-        primaryPhoneNumber: string;
-        secondaryPhoneNumber?: string;
-        emailAddress?: string;
-        country: string;
-        address: string;
-        postalCode: string;
-        city: string;
-        province: string;
-      };
-      birthDetails:
-        | { country: ServerEnvironment['PP_CANADA_COUNTRY_CODE']; province: string; city: string; fromMultipleBirth: boolean }
-        | { country: string; province?: string; city?: string; fromMultipleBirth: boolean };
-      parentDetails: (
-        | { unavailable: true }
-        | {
-            unavailable: false;
-            givenName: string;
-            lastName: string;
-            birthLocation:
-              | {
-                  country: 'CAN';
-                  province: string;
-                  city: string;
-                }
-              | {
-                  country: string;
-                  province?: string;
-                  city?: string;
-                };
-          }
-      )[];
-    }>;
+    inPersonSinApplications: Record<string, InPersonSinApplication | undefined>;
   }
 }
 

--- a/frontend/app/routes/protected/person-case/current-name.tsx
+++ b/frontend/app/routes/protected/person-case/current-name.tsx
@@ -5,7 +5,6 @@ import type { RouteHandle } from 'react-router';
 import { data, useFetcher } from 'react-router';
 
 import { faExclamationCircle, faXmark } from '@fortawesome/free-solid-svg-icons';
-import type { SessionData } from 'express-session';
 import type { ResourceKey } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import type { PartialDeep } from 'type-fest';
@@ -27,10 +26,9 @@ import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
 import { getTranslation } from '~/i18n-config.server';
 import { handle as parentHandle } from '~/routes/protected/layout';
+import type { CurrentNameData } from '~/routes/protected/person-case/@types';
 import { REGEX_PATTERNS } from '~/utils/regex-utils';
 import { trimToUndefined } from '~/utils/string-utils';
-
-type CurrentNameSessionData = NonNullable<SessionData['inPersonSINCase']['currentNameInfo']>;
 
 const REQUIRE_OPTIONS = {
   yes: 'Yes', //
@@ -55,15 +53,19 @@ export const handle = {
 
 export async function loader({ context, request }: Route.LoaderArgs) {
   requireAuth(context.session, new URL(request.url), ['user']);
+
+  const tabId = new URL(request.url).searchParams.get('tid') ?? '';
+  const sessionData = (context.session.inPersonSinApplications ??= {})[tabId];
+
   const { t } = await getTranslation(request, handle.i18nNamespace);
 
   return {
     documentTitle: t('protected:primary-identity-document.page-title'),
-    defaultFormValues: context.session.inPersonSINCase?.currentNameInfo,
+    defaultFormValues: sessionData?.currentNameInfo,
     primaryDocName: {
-      firstName: context.session.inPersonSINCase?.primaryDocuments?.givenName,
-      middleName: '', //context.session.inPersonSINCase?.primaryDocuments?.middleName,
-      lastName: context.session.inPersonSINCase?.primaryDocuments?.lastName,
+      firstName: sessionData?.primaryDocuments?.givenName,
+      middleName: '', //sessionData?.primaryDocuments?.middleName,
+      lastName: sessionData?.primaryDocuments?.lastName,
     },
   };
 }
@@ -77,6 +79,7 @@ export async function action({ context, request }: Route.ActionArgs) {
 
   const tabId = new URL(request.url).searchParams.get('tid');
   if (!tabId) throw new AppError('Missing tab id', ErrorCodes.MISSING_TAB_ID, { httpStatusCode: 400 });
+  const sessionData = ((context.session.inPersonSinApplications ??= {})[tabId] ??= {});
 
   const { lang, t } = await getTranslation(request, handle.i18nNamespace);
 
@@ -140,7 +143,7 @@ export async function action({ context, request }: Route.ActionArgs) {
           }),
         ],
         t('protected:current-name.preferred-name.required-error'),
-      ) satisfies v.GenericSchema<CurrentNameSessionData>;
+      ) satisfies v.GenericSchema<CurrentNameData>;
 
       const input = {
         preferredSameAsDocumentName: formData.get('same-name')
@@ -163,7 +166,7 @@ export async function action({ context, request }: Route.ActionArgs) {
         return data({ errors: v.flatten<typeof schema>(parseResult.issues).nested }, { status: 400 });
       }
 
-      (context.session.inPersonSINCase ??= {}).currentNameInfo = parseResult.output;
+      sessionData.currentNameInfo = parseResult.output;
 
       throw i18nRedirect('routes/protected/person-case/personal-info.tsx', request, {
         search: new URLSearchParams({ tid: tabId }),

--- a/frontend/app/routes/protected/person-case/layout.tsx
+++ b/frontend/app/routes/protected/person-case/layout.tsx
@@ -1,10 +1,14 @@
 import { Outlet } from 'react-router';
 
+import { faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
 import type { Route } from './+types/layout';
 
 import { useTabId } from '~/hooks/use-tab-id';
 
 export default function Layout({ actionData, loaderData, matches, params }: Route.ComponentProps) {
-  const tabId = useTabId(); // ensure we always have a tabId generated
+  const tabId = useTabId({ reloadDocument: true }); // ensure we always have a tabId generated
+  if (!tabId) return <FontAwesomeIcon className="m-8" icon={faSpinner} size="5x" spinPulse={true} />;
   return <Outlet context={{ tabId }} />;
 }


### PR DESCRIPTION
[AB#15081](https://dev.azure.com/ESDCCM/a4b4f7af-bbd7-4f0d-83ab-a123d0b70fda/_workitems/edit/15081) -- *explore XState for managing wizard screen flow*

## Summary

This PR adds browser-tab data isolation for the in-person application.

It manages this by storing the data for each flow in an isolated session slot which is indexed by a `tid` (tab id) search param (ex: `context.session.inPersonSinApplications[tabId]`).

The `tid` is auto-generated and added to the URL on demand as needed.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [x] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [x] linked this PR to a related issue (if applicable)
