### PR TITLE
fix(frontend): move `BASE_TIMEZONE` to client config

### DIFF
--- a/frontend/app/.server/environment/client.ts
+++ b/frontend/app/.server/environment/client.ts
@@ -2,10 +2,12 @@ import * as v from 'valibot';
 
 import { stringToBooleanSchema } from '~/.server/validation/string-to-boolean-schema';
 import { stringToIntegerSchema } from '~/.server/validation/string-to-integer-schema';
+import { isValidTimeZone } from '~/utils/date-utils';
 
 export type Client = Readonly<v.InferOutput<typeof client>>;
 
 export const defaults = {
+  BASE_TIMEZONE: 'Canada/Eastern',
   BUILD_DATE: '1970-01-01T00:00:00.000Z',
   BUILD_ID: '000000',
   BUILD_REVISION: '00000000',
@@ -22,6 +24,7 @@ export const defaults = {
  * ⚠️ IMPORTANT: DO NOT PUT SENSITIVE CONFIGURATIONS HERE ⚠️
  */
 export const client = v.object({
+  BASE_TIMEZONE: v.optional(v.pipe(v.string(), v.check(isValidTimeZone)), defaults.BASE_TIMEZONE),
   BUILD_DATE: v.optional(v.string(), defaults.BUILD_DATE),
   BUILD_ID: v.optional(v.string(), defaults.BUILD_ID),
   BUILD_REVISION: v.optional(v.string(), defaults.BUILD_REVISION),

--- a/frontend/app/.server/environment/server.ts
+++ b/frontend/app/.server/environment/server.ts
@@ -9,14 +9,12 @@ import { session, defaults as sessionDefaults } from '~/.server/environment/sess
 import { telemetry, defaults as telemetryDefaults } from '~/.server/environment/telemetry';
 import { LogFactory } from '~/.server/logging';
 import { stringToIntegerSchema } from '~/.server/validation/string-to-integer-schema';
-import { isValidTimeZone } from '~/utils/date-utils';
 
 const log = LogFactory.getLogger(import.meta.url);
 
 export type Server = Readonly<v.InferOutput<typeof server>>;
 
 export const defaults = {
-  BASE_TIMEZONE: 'Canada/Eastern',
   NODE_ENV: 'development',
   PORT: '3000',
   ...authenticationDefaults,
@@ -41,7 +39,6 @@ export const server = v.pipe(
     ...redis.entries,
     ...session.entries,
     ...telemetry.entries,
-    BASE_TIMEZONE: v.optional(v.pipe(v.string(), v.check(isValidTimeZone)), defaults.BASE_TIMEZONE),
     NODE_ENV: v.optional(v.picklist(['production', 'development', 'test']), defaults.NODE_ENV),
     PORT: v.optional(v.pipe(stringToIntegerSchema(), v.minValue(0)), defaults.PORT),
   }),


### PR DESCRIPTION
## Summary

This PR moves the `BASE_TIMEZONE` config value to client-side.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)
