### PR TITLE
fix validation schema in /contact-information

### DIFF
--- a/frontend/app/routes/protected/person-case/contact-information.tsx
+++ b/frontend/app/routes/protected/person-case/contact-information.tsx
@@ -79,40 +79,50 @@ export async function action({ context, params, request }: Route.ActionArgs) {
               v.email(t('protected:contact-information.error-messages.email-address-invalid-format')),
             ),
           ),
-          country: v.picklist(
-            countryService.getCountries().map(({ id }) => id),
-            t('protected:contact-information.error-messages.country-required'),
-          ),
-          address: v.pipe(v.string(), v.trim(), v.nonEmpty(t('protected:contact-information.error-messages.address-required'))),
-          postalCode: v.pipe(
-            v.string(),
-            v.trim(),
-            v.nonEmpty(t('protected:contact-information.error-messages.postal-code-required')),
-          ),
-          city: v.pipe(v.string(), v.trim(), v.nonEmpty(t('protected:contact-information.error-messages.city-required'))),
-          province: v.pipe(
-            v.string(),
-            v.trim(),
-            v.nonEmpty(t('protected:contact-information.error-messages.province-required')),
-          ),
         }),
-        v.variant('country', [
-          v.object({
-            country: v.literal(serverEnvironment.PP_CANADA_COUNTRY_CODE),
-            province: v.picklist(
-              provinceService.getProvinces().map(({ id }) => id),
-              t('protected:contact-information.error-messages.province-required'),
-            ),
-          }),
-          v.object({
-            country: v.string(),
-            province: v.pipe(
-              v.string(),
-              v.trim(),
-              v.nonEmpty(t('protected:contact-information.error-messages.province-required')),
-            ),
-          }),
-        ]),
+        v.variant(
+          'country',
+          [
+            v.object({
+              country: v.literal(serverEnvironment.PP_CANADA_COUNTRY_CODE),
+              province: v.picklist(
+                provinceService.getProvinces().map(({ id }) => id),
+                t('protected:contact-information.error-messages.province-required'),
+              ),
+              address: v.pipe(
+                v.string(),
+                v.trim(),
+                v.nonEmpty(t('protected:contact-information.error-messages.address-required')),
+              ),
+              postalCode: v.pipe(
+                v.string(),
+                v.trim(),
+                v.nonEmpty(t('protected:contact-information.error-messages.postal-code-required')),
+              ),
+              city: v.pipe(v.string(), v.trim(), v.nonEmpty(t('protected:contact-information.error-messages.city-required'))),
+            }),
+            v.object({
+              country: v.picklist(countryService.getCountries().map(({ id }) => id)),
+              province: v.pipe(
+                v.string(),
+                v.trim(),
+                v.nonEmpty(t('protected:contact-information.error-messages.province-required')),
+              ),
+              address: v.pipe(
+                v.string(),
+                v.trim(),
+                v.nonEmpty(t('protected:contact-information.error-messages.address-required')),
+              ),
+              postalCode: v.pipe(
+                v.string(),
+                v.trim(),
+                v.nonEmpty(t('protected:contact-information.error-messages.postal-code-required')),
+              ),
+              city: v.pipe(v.string(), v.trim(), v.nonEmpty(t('protected:contact-information.error-messages.city-required'))),
+            }),
+          ],
+          t('protected:contact-information.error-messages.country-required'),
+        ),
       ]) satisfies v.GenericSchema<ContactInformationData>;
 
       const input = {


### PR DESCRIPTION
## Summary

Previously, if a user were to submit the form without selecting a country, the validation errors for hidden inputs would be sent back to the client.  This PR fixes that issue.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades
