### PR TITLE
update(frontend): validation for other names on personal detail screen

### DIFF
--- a/frontend/app/.server/locales/protected-en.json
+++ b/frontend/app/.server/locales/protected-en.json
@@ -224,18 +224,22 @@
     "name-added-aria-label": "Name added: {{name}}, Activate to remove name",
     "removed-name-sr-message": "Name removed: {{name}}",
     "first-name-previously-used": {
+      "format": "Other first name must contain letters only.",
       "help-message-primary": "Type a name into the field and press Enter or click \"Add Name\" to save it.",
-      "label": "Other first names previously used"
+      "label": "Other first names previously used",
+      "max-length": "Other first name must contain at most {{maximum}} character(s)."
     },
     "last-name-at-birth": {
-      "format": "Last name must contain letters only.",
+      "format": "Last name at birth must contain letters only.",
       "label": "Last name at birth",
-      "max-length": "Last name must contain at most {{maximum}} character(s).",
+      "max-length": "Last name at birth must contain at most {{maximum}} character(s).",
       "required": "Last name is required."
     },
     "last-name-previously-used": {
+      "format": "Other last name must contain letters only.",
       "help-message-primary": "Type a name into the field and press Enter or click \"Add Name\" to save it.",
-      "label": "Other last names previously used"
+      "label": "Other last names previously used",
+      "max-length": "Other last name must contain at most {{maximum}} character(s)."
     },
     "gender": {
       "label": "Gender",

--- a/frontend/app/.server/locales/protected-fr.json
+++ b/frontend/app/.server/locales/protected-fr.json
@@ -225,8 +225,10 @@
     "name-added-aria-label": "Nom ajouté\u00a0: {{name}}, Activez pour supprimer le nom",
     "removed-name-sr-message": "Nom supprimé\u00a0: {{name}}",
     "first-name-previously-used": {
+      "format": "Le prénom doit contenir uniquement des lettres.",
       "help-message-primary": "Tapez un nom dans le champ et appuyez sur Entrée ou cliquez sur «\u00a0Ajouter un nom\u00a0» pour l'enregistrer.",
-      "label": "Autres prénoms précédemment utilisés"
+      "label": "Autres prénoms précédemment utilisés",
+      "max-length": "Le prénom doit contenir au maximum {{maximum}} caractère(s)."
     },
     "last-name-at-birth": {
       "format": "Le nom de famille doit contenir uniquement des lettres.",
@@ -235,8 +237,10 @@
       "required": "Le nom de famille est requis."
     },
     "last-name-previously-used": {
+      "format": "Le nom de famille doit contenir uniquement des lettres.",
       "help-message-primary": "Tapez un nom dans le champ et appuyez sur Entrée ou cliquez sur «\u00a0Ajouter un nom\u00a0» pour l'enregistrer.",
-      "label": "Autres noms de famille précédemment utilisés"
+      "label": "Autres noms de famille précédemment utilisés",
+      "max-length": "Le nom de famille doit contenir au maximum {{maximum}} caractère(s)."
     },
     "gender": {
       "label": "Genre",


### PR DESCRIPTION
## Summary
[AB16170](https://dev.azure.com/ESDCCM/FSIR/_workitems/edit/16170l)
On Personal detail screen, added validations on the following fields when Add name button is pressed. Both client side and server side validations are added.

Fields:
Other first names previously used
Other last names previously used 
Validation:
for max character length of 100, and names should not contain digits

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Screenshots

![image](https://github.com/user-attachments/assets/7fe44b8d-1928-4d19-aaaa-6e0b793bb9e1)
