### PR TITLE
refactor(gitops): de-integrate dev w/ Azure AD

### DIFF
--- a/gitops/overlays/dev/configs/future-sir-frontend/config.conf
+++ b/gitops/overlays/dev/configs/future-sir-frontend/config.conf
@@ -64,7 +64,8 @@ SESSION_COOKIE_DOMAIN=
 #   - `/my-app` restricts it to that path
 SESSION_COOKIE_PATH=
 
-# The SameSite attribute for the session cookie (default: strict).
+# The SameSite attribute for the session cookie (default: lax).
+# NOTE: setting this to 'strict' will break the Azure AD login flow.. (so maybe don't do that) 🥴
 # Valid values:
 #   - strict: the cookie will only be sent in same-site requests
 #   - lax: the cookie will be sent in same-site requests and cross-site top-level navigation
@@ -163,7 +164,7 @@ OTEL_USE_CONSOLE_TRACE_EXPORTER=
 # Valid values:
 #   - azuread: uses Azure Active Directory for authentication
 #   - local: use a local mock OIDC provider
-AUTH_DEFAULT_PROVIDER=
+AUTH_DEFAULT_PROVIDER=local
 
 
 
@@ -173,15 +174,15 @@ AUTH_DEFAULT_PROVIDER=
 
 # The Azure Active Directory issuer URL.
 # Used for OAuth2 or OpenID Connect authentication flows.
-AZUREAD_ISSUER_URL=https://login.microsoftonline.com/9ed55846-8a81-4246-acd8-b1a01abfc0d1/v2.0
+AZUREAD_ISSUER_URL=
 
 # The Azure AD client ID.
 # This identifies your application when interacting with Azure AD.
-AZUREAD_CLIENT_ID=fb240ef1-76a1-42a5-abcb-1d95ec0d6a0e
+AZUREAD_CLIENT_ID=
 
 # The Azure AD client secret.
 # This is used to authenticate your application with Azure AD.
-# AZUREAD_CLIENT_SECRET=‼ set via k8s secret ‼
+AZUREAD_CLIENT_SECRET=
 
 
 

--- a/gitops/overlays/dev/external-secrets.yaml
+++ b/gitops/overlays/dev/external-secrets.yaml
@@ -12,13 +12,10 @@ spec:
   target:
     template:
       data:
-        AZUREAD_CLIENT_SECRET: '{{ .AZUREAD_CLIENT_SECRET }}'
         OTEL_AUTH_HEADER: 'Api-Token {{ .OTEL_AUTH_HEADER }}'
         REDIS_PASSWORD: '{{ .REDIS_PASSWORD }}'
         SESSION_COOKIE_SECRET: '{{ .SESSION_COOKIE_SECRET  }}'
   data:
-    - secretKey: AZUREAD_CLIENT_SECRET
-      remoteRef: { key: dev, property: AZUREAD_CLIENT_SECRET }
     - secretKey: OTEL_AUTH_HEADER
       remoteRef: { key: dev, property: DT_ACCESS_TOKEN }
     - secretKey: REDIS_PASSWORD


### PR DESCRIPTION
## Summary

De-integrate the dev pseudoenvironment with Azure AD, since we now have a dedicated int environment for integration testing.
