### PR TITLE
add phone number transform to validation schema

### DIFF
--- a/frontend/app/routes/protected/person-case/contact-information.tsx
+++ b/frontend/app/routes/protected/person-case/contact-information.tsx
@@ -3,6 +3,7 @@ import { useId, useState } from 'react';
 import type { RouteHandle } from 'react-router';
 import { data, redirect, useFetcher } from 'react-router';
 
+import { parsePhoneNumberWithError } from 'libphonenumber-js';
 import { useTranslation } from 'react-i18next';
 import * as v from 'valibot';
 
@@ -70,8 +71,15 @@ export async function action({ context, params, request }: Route.ActionArgs) {
             v.string(),
             v.trim(),
             v.nonEmpty(t('protected:contact-information.error-messages.primary-phone-required')),
+            v.transform((val) => parsePhoneNumberWithError(val, 'CA').formatInternational().replace(/ /g, '')),
           ),
-          secondaryPhoneNumber: v.optional(v.pipe(v.string(), v.trim())),
+          secondaryPhoneNumber: v.optional(
+            v.pipe(
+              v.string(),
+              v.trim(),
+              v.transform((val) => parsePhoneNumberWithError(val, 'CA').formatInternational().replace(/ /g, '')),
+            ),
+          ),
           emailAddress: v.optional(
             v.pipe(
               v.string(),


### PR DESCRIPTION
## Summary

Previously if a user were to enter a valid phone number, submit the form without error, and navigate back to `/contact-information`, the phone number would not be rendered to the client.  A console error reveals that the phone number isn't formatted as an E.164 number.  This PR addresses that issue by adding a transform to leverage `libphonenumber-js` and strip any subsequent white space.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>
