### PR TITLE
fix(frontend): apply security response headers to all requests

### DIFF
--- a/frontend/app/.server/express/middleware.ts
+++ b/frontend/app/.server/express/middleware.ts
@@ -78,7 +78,8 @@ export function security(environment: ServerEnvironment): RequestHandler {
       `img-src 'self' data: www.canada.ca`,
       `object-src data:`,
       `script-src 'self' 'nonce-${response.locals.nonce}'`,
-      // unsafe-inline is required by Radix Primitives 💩
+      // NOTE: unsafe-inline is required by Radix Primitives 💩
+      // see https://github.com/radix-ui/primitives/discussions/3130
       `style-src 'self' 'unsafe-inline' fonts.googleapis.com use.fontawesome.com www.canada.ca`,
     ].join('; ');
 

--- a/frontend/app/.server/express/server.ts
+++ b/frontend/app/.server/express/server.ts
@@ -48,6 +48,9 @@ app.use(compression());
 log.info('    ✓ logging middleware');
 app.use(logging(serverEnvironment));
 
+log.info('    ✓ security headers middleware');
+app.use(security(serverEnvironment));
+
 if (serverEnvironment.isProduction) {
   log.info('    ✓ static assets middleware (production)');
   log.info('      ✓ caching /assets for 1y');
@@ -63,9 +66,6 @@ if (serverEnvironment.isProduction) {
   log.info('      ✓ caching remaining static content for 1h');
   app.use(express.static('./public', { maxAge: '1h' }));
 }
-
-log.info('    ✓ security headers middleware');
-app.use(security(serverEnvironment));
 
 log.info('    ✓ session middleware (%s)', serverEnvironment.SESSION_TYPE);
 app.use(session(serverEnvironment));


### PR DESCRIPTION
## Summary

ZAProxy was complaining about missing security headers for some requests. To fix this, I moved the security middleware higher up in the call stack to ensure that it gets triggered for all requests.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)
