### PR TITLE
fix(infra): make oauth client public

### DIFF
--- a/infrastructure/terragrunt/nonprod/frontend-service-principal/terragrunt.hcl
+++ b/infrastructure/terragrunt/nonprod/frontend-service-principal/terragrunt.hcl
@@ -19,6 +19,7 @@ inputs = {
   app_name            = "Future SIR: Frontend Service Principal (nonprod)"
   app_identifier_uris = ["api://nonprod.future-sir.esdc-edsc.gc.ca/frontend"]
   app_passwords       = ["Default secret"]
+  app_public          = true # TODO ::: GjB ::: temporarily enabled to help 'CC' on the power-platform team... disable at a later date
   app_web_redirect_uris = [
     "http://localhost:3000/auth/callback/azuread",
     "https://future-sir-dev.dev-dp-internal.dts-stn.com/auth/callback/azuread",


### PR DESCRIPTION
## Summary

"CC" (name redacted) on the power-platform team requires our app registration (oauth client) to be temporarily public. We can remove this setting once he is finished his R&D work.
