### PR TITLE
refactor(frontend): fix the typescript error on getStateRoute

### DIFF
--- a/frontend/app/routes/protected/person-case/abandon.tsx
+++ b/frontend/app/routes/protected/person-case/abandon.tsx
@@ -35,5 +35,5 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     }
   }
 
-  throw redirect(getStateRoute(machineActor, { params, request }));
+  throw redirect(getStateRoute(machineActor, { context, params, request }));
 }

--- a/frontend/app/routes/protected/person-case/birth-details.tsx
+++ b/frontend/app/routes/protected/person-case/birth-details.tsx
@@ -139,7 +139,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     }
   }
 
-  throw redirect(getStateRoute(machineActor, { params, request }));
+  throw redirect(getStateRoute(machineActor, { context, params, request }));
 }
 
 export async function loader({ context, params, request }: Route.LoaderArgs) {

--- a/frontend/app/routes/protected/person-case/contact-information.tsx
+++ b/frontend/app/routes/protected/person-case/contact-information.tsx
@@ -162,7 +162,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     }
   }
 
-  throw redirect(getStateRoute(machineActor, { params, request }));
+  throw redirect(getStateRoute(machineActor, { context, params, request }));
 }
 
 export async function loader({ context, request }: Route.LoaderArgs) {

--- a/frontend/app/routes/protected/person-case/current-name.tsx
+++ b/frontend/app/routes/protected/person-case/current-name.tsx
@@ -159,7 +159,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     }
   }
 
-  throw redirect(getStateRoute(machineActor, { params, request }));
+  throw redirect(getStateRoute(machineActor, { context, params, request }));
 }
 
 export async function loader({ context, request }: Route.LoaderArgs) {

--- a/frontend/app/routes/protected/person-case/parent-details.tsx
+++ b/frontend/app/routes/protected/person-case/parent-details.tsx
@@ -181,7 +181,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     }
   }
 
-  throw redirect(getStateRoute(machineActor, { params, request }));
+  throw redirect(getStateRoute(machineActor, { context, params, request }));
 }
 
 export async function loader({ context, request }: Route.LoaderArgs) {

--- a/frontend/app/routes/protected/person-case/personal-info.tsx
+++ b/frontend/app/routes/protected/person-case/personal-info.tsx
@@ -115,7 +115,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     }
   }
 
-  throw redirect(getStateRoute(machineActor, { params, request }));
+  throw redirect(getStateRoute(machineActor, { context, params, request }));
 }
 
 export async function loader({ context, request }: Route.LoaderArgs) {

--- a/frontend/app/routes/protected/person-case/previous-sin.tsx
+++ b/frontend/app/routes/protected/person-case/previous-sin.tsx
@@ -113,7 +113,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     }
   }
 
-  throw redirect(getStateRoute(machineActor, { params, request }));
+  throw redirect(getStateRoute(machineActor, { context, params, request }));
 }
 
 export async function loader({ context, request }: Route.LoaderArgs) {

--- a/frontend/app/routes/protected/person-case/primary-docs.tsx
+++ b/frontend/app/routes/protected/person-case/primary-docs.tsx
@@ -228,7 +228,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     }
   }
 
-  throw redirect(getStateRoute(machineActor, { params, request }));
+  throw redirect(getStateRoute(machineActor, { context, params, request }));
 }
 
 export async function loader({ context, request }: Route.LoaderArgs) {

--- a/frontend/app/routes/protected/person-case/privacy-statement.tsx
+++ b/frontend/app/routes/protected/person-case/privacy-statement.tsx
@@ -72,7 +72,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     }
   }
 
-  throw redirect(getStateRoute(machineActor, { params, request }));
+  throw redirect(getStateRoute(machineActor, { context, params, request }));
 }
 
 export async function loader({ context, request }: Route.LoaderArgs) {

--- a/frontend/app/routes/protected/person-case/request-details.tsx
+++ b/frontend/app/routes/protected/person-case/request-details.tsx
@@ -99,7 +99,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     }
   }
 
-  throw redirect(getStateRoute(machineActor, { params, request }));
+  throw redirect(getStateRoute(machineActor, { context, params, request }));
 }
 
 export async function loader({ context, request }: Route.LoaderArgs) {

--- a/frontend/app/routes/protected/person-case/review.tsx
+++ b/frontend/app/routes/protected/person-case/review.tsx
@@ -74,7 +74,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     }
   }
 
-  throw redirect(getStateRoute(machineActor, { params, request }));
+  throw redirect(getStateRoute(machineActor, { context, params, request }));
 }
 
 export async function loader({ context, request }: Route.LoaderArgs) {

--- a/frontend/app/routes/protected/person-case/secondary-doc.tsx
+++ b/frontend/app/routes/protected/person-case/secondary-doc.tsx
@@ -116,7 +116,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     }
   }
 
-  throw redirect(getStateRoute(machineActor, { params, request }));
+  throw redirect(getStateRoute(machineActor, { context, params, request }));
 }
 
 export async function loader({ context, request }: Route.LoaderArgs) {


### PR DESCRIPTION
## Summary

On main branch, there is typescript error when you run npm run checks, this pr fix this error.

Error:
Property 'context' is missing in type '{ params: { [key: string]: string | undefined; }; request: Request; }' but required in type 'ActionFunctionArgs<any>'.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
