### PR TITLE
refactor(frontend): rename Interop API environment variables for clarity

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -213,7 +213,7 @@ PP_HAS_HAD_PREVIOUS_SIN_CODE=
 #################################################
 
 # Autentication header value (default: Ocp-Apim-Subscription-Key 00000000000000000000000000000000).
-INTEROP_API_AUTH_HEADER=
+INTEROP_SIN_REG_API_AUTH_HEADER=
 
 # The base URL to use for all Interop API calls (default: http://localhost:3000/api)
-INTEROP_API_BASE_URL=
+INTEROP_SIN_REG_API_BASE_URL=

--- a/frontend/app/.server/environment/interop-api.ts
+++ b/frontend/app/.server/environment/interop-api.ts
@@ -5,11 +5,14 @@ import { Redacted } from '~/.server/utils/security-utils';
 export type InteropApi = Readonly<v.InferOutput<typeof interopApi>>;
 
 export const defaults = {
-  INTEROP_API_AUTH_HEADER: 'Ocp-Apim-Subscription-Key 00000000000000000000000000000000',
-  INTEROP_API_BASE_URL: 'http://localhost:3000/api',
+  INTEROP_SIN_REG_API_AUTH_HEADER: 'Ocp-Apim-Subscription-Key 00000000000000000000000000000000',
+  INTEROP_SIN_REG_API_BASE_URL: 'http://localhost:3000/api',
 } as const;
 
 export const interopApi = v.object({
-  INTEROP_API_AUTH_HEADER: v.pipe(v.optional(v.string(), defaults.INTEROP_API_AUTH_HEADER), v.transform(Redacted.make)),
-  INTEROP_API_BASE_URL: v.optional(v.string(), defaults.INTEROP_API_BASE_URL),
+  INTEROP_SIN_REG_API_AUTH_HEADER: v.pipe(
+    v.optional(v.string(), defaults.INTEROP_SIN_REG_API_AUTH_HEADER),
+    v.transform(Redacted.make),
+  ),
+  INTEROP_SIN_REG_API_BASE_URL: v.optional(v.string(), defaults.INTEROP_SIN_REG_API_BASE_URL),
 });

--- a/frontend/app/.server/shared/api/interop-client-config.ts
+++ b/frontend/app/.server/shared/api/interop-client-config.ts
@@ -15,11 +15,11 @@ const log = LogFactory.getLogger(import.meta.url);
 export function createClientConfig<T extends ClientOptions>(
   config?: Config<ClientOptions & T>,
 ): Config<Required<ClientOptions> & T> {
-  const authHeader = serverEnvironment.INTEROP_API_AUTH_HEADER.value();
+  const authHeader = serverEnvironment.INTEROP_SIN_REG_API_AUTH_HEADER.value();
 
   return {
     ...config,
-    baseUrl: serverEnvironment.INTEROP_API_BASE_URL,
+    baseUrl: serverEnvironment.INTEROP_SIN_REG_API_BASE_URL,
     headers: { ...parseAuthorizationHeader(authHeader) },
   };
 }


### PR DESCRIPTION
## Summary

Since there can eventually be more than one interop API, I've renamed the existing one for clarity.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)
