### PR TITLE
fix(frontend): fix type definitions for `BirthDetailsData` and `ParentDetailsData`

### DIFF
--- a/frontend/app/routes/protected/person-case/types.d.ts
+++ b/frontend/app/routes/protected/person-case/types.d.ts
@@ -1,12 +1,14 @@
 import 'express-session';
 import type { SnapshotFrom } from 'xstate';
 
-import type { ServerEnvironment } from '~/.server/environment';
 import type { Machine } from '~/routes/protected/person-case/state-machine.server';
 
-export type BirthDetailsData =
-  | { country: ServerEnvironment['PP_CANADA_COUNTRY_CODE']; province: string; city: string; fromMultipleBirth: boolean }
-  | { country: string; province?: string; city?: string; fromMultipleBirth: boolean };
+export type BirthDetailsData = {
+  country: string;
+  province?: string;
+  city?: string;
+  fromMultipleBirth: boolean;
+};
 
 export type ContactInformationData = {
   preferredLanguage: string;
@@ -28,8 +30,11 @@ export type CurrentNameData =
       middleName?: string;
       lastName: string;
       supportingDocuments:
-        | { required: false } //
-        | { required: true; documentTypes: string[] };
+        | { required: false }
+        | {
+            required: true;
+            documentTypes: string[];
+          };
     };
 
 export type ParentDetailsData = (
@@ -38,9 +43,11 @@ export type ParentDetailsData = (
       unavailable: false;
       givenName: string;
       lastName: string;
-      birthLocation:
-        | { country: 'CAN'; province: string; city: string } //
-        | { country: string; province?: string; city?: string };
+      birthLocation: {
+        country: string;
+        province?: string;
+        city?: string;
+      };
     }
 )[];
 


### PR DESCRIPTION
## Summary

The type definitions for `BirthDetailsData` and `ParentDetailsData` were incorrect.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)
