### PR TITLE
chore(gitops): sync dev config ↔ .env.example

### DIFF
--- a/gitops/overlays/dev/configs/future-sir-frontend/config.conf
+++ b/gitops/overlays/dev/configs/future-sir-frontend/config.conf
@@ -205,3 +205,15 @@ PP_CANADA_COUNTRY_CODE=
 # Power Platform lanuage code for `Did the Applicant Ever Had a SIN Number?` (default: 564190000)
 # see app/.server/resources/esdc_didtheapplicanteverhadasinnumber.json
 PP_HAS_HAD_PREVIOUS_SIN_CODE=
+
+
+
+#################################################
+# Interop API configuration
+#################################################
+
+# Autentication header value (default: Ocp-Apim-Subscription-Key 00000000000000000000000000000000).
+INTEROP_SIN_REG_API_AUTH_HEADER=
+
+# The base URL to use for all Interop API calls (default: http://localhost:3000/api)
+INTEROP_SIN_REG_API_BASE_URL=


### PR DESCRIPTION
## Summary

Trivial PR to sync dev config with .env.example (to make it easier to diff).
