### PR TITLE
refactor(frontend): display localized SIN options on review page

### DIFF
--- a/frontend/app/routes/protected/person-case/review.tsx
+++ b/frontend/app/routes/protected/person-case/review.tsx
@@ -10,6 +10,7 @@ import type { Info, Route } from './+types/review';
 
 import {
   applicantGenderService,
+  applicantSinService,
   applicantSecondaryDocumentService,
   languageCorrespondenceService,
 } from '~/.server/domain/person-case/services';
@@ -151,6 +152,13 @@ export async function loader({ context, request }: Route.LoaderArgs) {
             ? inPersonSinApplication.contactInformation.province
             : provinceService.getLocalizedProvinceById(inPersonSinApplication.contactInformation.province, lang).name
           : undefined,
+      },
+      previousSin: {
+        ...inPersonSinApplication.previousSin,
+        hasPreviousSinText: applicantSinService.getLocalizedApplicantHadSinOptionById(
+          inPersonSinApplication.previousSin.hasPreviousSin,
+          lang,
+        ).name,
       },
     },
     tabId,
@@ -510,7 +518,7 @@ function PreviousSinData({ data, tabId }: DataProps) {
       <h2 className="font-lato text-2xl font-bold">{t('protected:previous-sin.page-title')}</h2>
       <DescriptionList className="divide-y border-y">
         <DescriptionListItem term={t('protected:previous-sin.has-previous-sin-label')}>
-          <p>{data.hasPreviousSin}</p>
+          <p>{data.hasPreviousSinText}</p>
         </DescriptionListItem>
         {data.socialInsuranceNumber && (
           <DescriptionListItem term={t('protected:previous-sin.social-insurance-number-label')}>


### PR DESCRIPTION
## Summary

[AB1485](https://dev.azure.com/ESDCCM/FSIR/_workitems/edit/14685)
display localized SIN options on review page.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Has the applicant ever had a SIN? option in Previous SIN wasn't displaying the text value:
![image](https://github.com/user-attachments/assets/98ba0187-f72e-4514-b137-d6bb4d61f60a)
changed to display the text value:
![image](https://github.com/user-attachments/assets/db2300aa-5c22-4db8-b4d8-c6981af81d54)

