### PR TITLE
fix(frontend): configure vscode to import all files from root (~)

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -13,13 +13,21 @@
   // Tailwind Regex List
   // see: https://github.com/paolotiu/tailwind-intellisense-regex-list?tab=readme-ov-file#classnames
   "tailwindCSS.experimental.classRegex": [
-    // clsx and cn
     ["clsx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"],
     ["cn\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"],
-    // JavaScript string variable with keywords
     [
+      // JavaScript string that likely contains tailwind classes.
+      // This regex looks for lines of JavaScript code that:
+      //
+      // 1. Optionally start with `const`, `let`, or `var`.
+      // 2. Have a variable name, that:
+      // 3. End with `styles`, `classes`, or `classnames`.
+      // 4. Have an equals sign (=) or +=.
+      // 5. Have a string in single or double quotes.
       "(?:\\b(?:const|let|var)\\s+)?[\\w$_]*(?:[Ss]tyles|[Cc]lasses|[Cc]lassnames)[\\w\\d]*\\s*(?:=|\\+=)\\s*['\"]([^'\"]*)['\"]"
     ]
   ],
+  // always import files from the root (~) of the project
+  "typescript.preferences.importModuleSpecifier": "non-relative",
   "vitest.disableWorkspaceWarning": true
 }


### PR DESCRIPTION
## Summary

Add a setting to vscode that will instruct it to always import from the root (`~`) instead of using a relative import.

(also doc-commented the existing tailwind regex)