### PR TITLE
feat(frontend): Update finalize screen with province auto-select

### DIFF
--- a/frontend/app/routes/protected/multi-channel/finalize-request.tsx
+++ b/frontend/app/routes/protected/multi-channel/finalize-request.tsx
@@ -34,6 +34,9 @@ export async function loader({ context, request }: Route.LoaderArgs) {
 
   const { t, lang } = await getTranslation(request, handle.i18nNamespace);
 
+  //TODO: Update with the province of the office that is in the session
+  const officeProvinceCode = 'ON';
+
   return {
     documentTitle: t('protected:finalize-request.page-title'),
     localizedRcCodeData: serverEnvironment.RC_CODES.map(({ RC_CODE, alphaCode }) => ({
@@ -41,7 +44,7 @@ export async function loader({ context, request }: Route.LoaderArgs) {
       province: getLocalizedProvinceByAlphaCode(alphaCode, lang).name,
     })),
     defaultFormValues: {
-      originOfSin: undefined,
+      originOfSin: serverEnvironment.RC_CODES.find(({ alphaCode }) => alphaCode === officeProvinceCode)?.RC_CODE,
       declaration: undefined,
     },
   };


### PR DESCRIPTION
## Summary
[AB19138](https://dev.azure.com/ESDCCM/FSIR/_workitems/edit/19138) Update Finalize screen to auto-select office's province code
- Modified finalize screen to automatically select the province.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/dededb81-4a3b-47e8-a64f-9549cc4fede5)
