### PR TITLE
refactor(frontend): change how the form data+errors persist

### DIFF
--- a/frontend/app/routes/protected/person-case/types.d.ts
+++ b/frontend/app/routes/protected/person-case/types.d.ts
@@ -3,6 +3,13 @@ import type { SnapshotFrom } from 'xstate';
 
 import type { Machine } from '~/routes/protected/person-case/state-machine.server';
 
+export type FormData = {
+  [K in keyof InPersonSinApplication]?: {
+    values?: Record<string, string | undefined>;
+    errors?: Record<string, [string, ...string[]] | undefined>;
+  };
+};
+
 export type BirthDetailsData = {
   country: string;
   province?: string;
@@ -101,16 +108,6 @@ export type InPersonSinApplication = {
   privacyStatement: PrivacyStatementData;
   requestDetails: RequestDetailsData;
   secondaryDocument: SecondaryDocumentData;
-  rawDataMap: RawDataMap;
-};
-
-export type RawData<K extends keyof InPersonSinApplication> = {
-  formData: InPersonSinApplication[K];
-  errors?: Record<string, [string, ...string[]] | undefined>;
-};
-
-export type RawDataMap = {
-  [K in keyof InPersonSinApplication]?: RawData<K>;
 };
 
 declare module 'express-session' {


### PR DESCRIPTION
## Summary

Refactor the form persistence code:

- Rename `rawDataMap` to `formData` to be more descriptive (I think)
- Re-type the form data to be a little more lenient
- Move form data reset calls into machine actions
- Refactor loaders/actions/components to use `loaderData.formValues` and `loaderData.formErrors` (instead of `defaultFormValues`, etc)

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)
