### PR TITLE
add previous button to privacy statement

### DIFF
--- a/frontend/app/routes/protected/person-case/layout.tsx
+++ b/frontend/app/routes/protected/person-case/layout.tsx
@@ -30,9 +30,7 @@ export default function Layout({ actionData, loaderData, matches, params }: Rout
   const abandonAction = i18n.language == 'fr' ? abandonRoute.paths.fr : abandonRoute.paths.en;
 
   if (!tabId) {
-    // if there is no tab id, render a spinner and wait for one to be generated
-    // TODO ::: GjB ::: this is horribly styled
-    return <FontAwesomeIcon className="m-8" icon={faSpinner} size="5x" spinPulse={true} />;
+    return <FontAwesomeIcon className="m-8 animate-[spin_3s_infinite_linear] text-slate-800" icon={faSpinner} size="3x" />;
   }
 
   return (

--- a/frontend/app/routes/protected/person-case/privacy-statement.tsx
+++ b/frontend/app/routes/protected/person-case/privacy-statement.tsx
@@ -48,6 +48,11 @@ export async function action({ context, params, request }: Route.ActionArgs) {
   const action = formData.get('action');
 
   switch (action) {
+    case 'back': {
+      machineActor.send({ type: 'exit' });
+      throw i18nRedirect('routes/protected/index.tsx', request);
+    }
+
     case 'next': {
       const parseResult = v.safeParse(privacyStatementSchema, {
         agreedToTerms: formData.get('agreedToTerms') ? true : undefined,
@@ -118,6 +123,9 @@ export default function PrivacyStatement({ loaderData, params }: Route.Component
           <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
             <Button name="action" value="next" variant="primary" id="continue-button" disabled={isSubmitting}>
               {t('protected:person-case.next')}
+            </Button>
+            <Button name="action" value="back" id="back-button" disabled={isSubmitting}>
+              {t('protected:person-case.previous')}
             </Button>
           </div>
         </fetcher.Form>

--- a/frontend/app/routes/protected/person-case/state-machine.server.ts
+++ b/frontend/app/routes/protected/person-case/state-machine.server.ts
@@ -34,6 +34,7 @@ type MachineContext = Partial<InPersonSinApplication> & Partial<{ formData: Form
 type MachineEvents =
   | { type: 'prev' }
   | { type: 'cancel' }
+  | { type: 'exit' }
   | { type: 'setFormData'; data: FormData }
   | { type: 'submitBirthDetails'; data: BirthDetailsData }
   | { type: 'submitContactInfo'; data: ContactInformationData }
@@ -101,13 +102,12 @@ export const machine = setup({
       target: '.privacy-statement',
       actions: assign(initialContext),
     },
-    setFormData: {
-      actions: assign(({ context, event }) => ({
-        formData: { ...context.formData, ...event.data },
-      })),
+    exit: {
+      target: '.exited',
     },
   },
   states: {
+    'exited': { type: 'final' },
     'privacy-statement': {
       meta: { route: 'routes/protected/person-case/privacy-statement.tsx' },
       on: {


### PR DESCRIPTION
## Summary

Adds a previous button to the privacy statement screen.  This requires modifying the state machine to handle an exit action which should reset the context and also remove the `tid` from the search param upon navigating back to the index screen.

Also updated the style of the spinner in the layout, but honestly the styling isn't really that bad to being with so this is just a shoehorn to remove a todo.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
