### PR TITLE
feat(frontend): Send validation screen updates session with fetched application

### DIFF
--- a/frontend/app/i18n-routes.ts
+++ b/frontend/app/i18n-routes.ts
@@ -104,36 +104,41 @@ export const i18nRoutes = [
         paths: { en: '/en/protected/request', fr: '/fr/protege/requete' },
       },
       {
-        id: 'MCF-0001',
-        file: 'routes/protected/multi-channel/pid-verification.tsx',
-        paths: {
-          en: '/en/protected/multi-channel/pid-verification',
-          fr: '/fr/protege/multi-chaine/pid-verification',
-        },
-      },
-      {
-        id: 'MCF-0002',
-        file: 'routes/protected/multi-channel/search-sin.tsx',
-        paths: {
-          en: '/en/protected/multi-channel/search-sin',
-          fr: '/fr/protege/multi-chaine/search-sin',
-        },
-      },
-      {
-        id: 'MCF-0003',
-        file: 'routes/protected/multi-channel/finalize-request.tsx',
-        paths: {
-          en: '/en/protected/multi-channel/finalize-request',
-          fr: '/fr/protege/multi-chaine/finalize-request',
-        },
-      },
-      {
-        id: 'MCF-0004',
-        file: 'routes/protected/multi-channel/send-validation.tsx',
-        paths: {
-          en: '/en/protected/multi-channel/send-validation',
-          fr: '/fr/protege/multi-chaine/send-validation',
-        },
+        file: 'routes/protected/multi-channel/layout.tsx',
+        children: [
+          {
+            id: 'MCF-0001',
+            file: 'routes/protected/multi-channel/pid-verification.tsx',
+            paths: {
+              en: '/en/protected/multi-channel/pid-verification',
+              fr: '/fr/protege/multi-chaine/pid-verification',
+            },
+          },
+          {
+            id: 'MCF-0002',
+            file: 'routes/protected/multi-channel/search-sin.tsx',
+            paths: {
+              en: '/en/protected/multi-channel/search-sin',
+              fr: '/fr/protege/multi-chaine/search-sin',
+            },
+          },
+          {
+            id: 'MCF-0003',
+            file: 'routes/protected/multi-channel/finalize-request.tsx',
+            paths: {
+              en: '/en/protected/multi-channel/finalize-request',
+              fr: '/fr/protege/multi-chaine/finalize-request',
+            },
+          },
+          {
+            id: 'MCF-0004',
+            file: 'routes/protected/multi-channel/send-validation.tsx',
+            paths: {
+              en: '/en/protected/multi-channel/send-validation',
+              fr: '/fr/protege/multi-chaine/send-validation',
+            },
+          },
+        ],
       },
       {
         file: 'routes/protected/person-case/layout.tsx',

--- a/frontend/app/routes/protected/multi-channel/layout.tsx
+++ b/frontend/app/routes/protected/multi-channel/layout.tsx
@@ -1,0 +1,28 @@
+import type { RouteHandle } from 'react-router';
+import { Outlet } from 'react-router';
+
+import { faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import type { Route } from './+types/layout';
+
+import { useTabId } from '~/hooks/use-tab-id';
+import { handle as parentHandle } from '~/routes/protected/layout';
+
+export const handle = {
+  i18nNamespace: [...parentHandle.i18nNamespace, 'protected'],
+} as const satisfies RouteHandle;
+
+export default function Layout({ actionData, loaderData, matches, params }: Route.ComponentProps) {
+  const tabId = useTabId({ reloadDocument: true }); // ensure we always have a tabId generated
+
+  if (!tabId) {
+    return <FontAwesomeIcon className="m-8 animate-[spin_3s_infinite_linear] text-slate-800" icon={faSpinner} size="3x" />;
+  }
+
+  return (
+    <>
+      <Outlet context={{ tabId }} />
+    </>
+  );
+}

--- a/frontend/app/routes/protected/multi-channel/send-validation.tsx
+++ b/frontend/app/routes/protected/multi-channel/send-validation.tsx
@@ -24,6 +24,7 @@ import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
 import { getTranslation } from '~/i18n-config.server';
 import { handle as parentHandle } from '~/routes/protected/person-case/layout';
+import { createMachineActor } from '~/routes/protected/person-case/state-machine.server';
 import { SinApplication } from '~/routes/protected/sin-application';
 
 export const handle = {
@@ -58,7 +59,9 @@ export async function loader({ context, request }: Route.LoaderArgs) {
   // TODO: Update with the actual fetch method
   const { inPersonSinApplication, caseId } = fetchInPersonSinApplication();
 
-  //TODO: Update Session with fetched SIN application
+  if (tabId) {
+    createMachineActor(context.session, request).send({ type: 'setSinApplication', data: inPersonSinApplication });
+  }
 
   return {
     documentTitle: t('protected:send-validation.page-title'),
@@ -184,7 +187,7 @@ function fetchInPersonSinApplication(): {
 
   const contactInformation = {
     preferredLanguage: '564190000',
-    primaryPhoneNumber: '780111111',
+    primaryPhoneNumber: '+1780111111',
     secondaryPhoneNumber: undefined,
     emailAddress: undefined,
     country: 'f8914e7c-2c95-ea11-a812-000d3a0c2b5d',

--- a/frontend/app/routes/protected/person-case/state-machine.server.ts
+++ b/frontend/app/routes/protected/person-case/state-machine.server.ts
@@ -36,6 +36,7 @@ type MachineEvents =
   | { type: 'cancel' }
   | { type: 'exit' }
   | { type: 'setFormData'; data: FormData }
+  | { type: 'setSinApplication'; data: InPersonSinApplication }
   | { type: 'submitBirthDetails'; data: BirthDetailsData }
   | { type: 'submitContactInfo'; data: ContactInformationData }
   | { type: 'submitCurrentName'; data: CurrentNameData }
@@ -108,6 +109,12 @@ export const machine = setup({
     setFormData: {
       actions: assign(({ context, event }) => ({
         formData: { ...context.formData, ...event.data },
+      })),
+    },
+    setSinApplication: {
+      actions: assign(({ context, event }) => ({
+        ...context,
+        ...event.data,
       })),
     },
   },


### PR DESCRIPTION
## Summary
[AB18962](https://dev.azure.com/ESDCCM/FSIR/_workitems/edit/18962)
Send validation screen updates session with fetched application

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
