### PR TITLE
feat(frontend): add reusable list components

### DIFF
--- a/frontend/app/components/error-boundaries.tsx
+++ b/frontend/app/components/error-boundaries.tsx
@@ -5,6 +5,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import type { Route } from '../+types/root';
 
 import { AppLink } from '~/components/links';
+import { UnorderedList } from '~/components/lists';
 import { PageTitle } from '~/components/page-title';
 import { isAppError } from '~/errors/app-error';
 import { HttpStatusCodes } from '~/errors/http-status-codes';
@@ -64,7 +65,7 @@ export function BilingualErrorBoundary({ actionData, error, loaderData, params }
               </PageTitle>
               <p className="mb-8 text-lg text-gray-500">{en('gcweb:server-error.page-message')}</p>
               {isAppError(error) && (
-                <ul className="list-disc pl-10 text-gray-800">
+                <UnorderedList className="text-gray-800">
                   <li>
                     <Trans
                       t={en}
@@ -81,7 +82,7 @@ export function BilingualErrorBoundary({ actionData, error, loaderData, params }
                       values={{ correlationId: error.correlationId }}
                     />
                   </li>
-                </ul>
+                </UnorderedList>
               )}
             </div>
             <div id="french" lang="fr">
@@ -97,7 +98,7 @@ export function BilingualErrorBoundary({ actionData, error, loaderData, params }
               </PageTitle>
               <p className="mb-8 text-lg text-gray-500">{fr('gcweb:server-error.page-message')}</p>
               {isAppError(error) && (
-                <ul className="list-disc pl-10 text-gray-800">
+                <UnorderedList className="text-gray-800">
                   <li>
                     <Trans
                       t={fr}
@@ -114,7 +115,7 @@ export function BilingualErrorBoundary({ actionData, error, loaderData, params }
                       values={{ correlationId: error.correlationId }}
                     />
                   </li>
-                </ul>
+                </UnorderedList>
               )}
             </div>
           </div>
@@ -282,7 +283,7 @@ export function UnilingualErrorBoundary({ actionData, error, loaderData, params 
           </PageTitle>
           <p className="mb-8 text-lg text-gray-500">{t('gcweb:server-error.page-message')}</p>
           {isAppError(error) && (
-            <ul className="list-disc pl-10 text-gray-800">
+            <UnorderedList className="text-gray-800">
               <li>
                 <Trans
                   i18nKey="gcweb:server-error.error-code"
@@ -297,7 +298,7 @@ export function UnilingualErrorBoundary({ actionData, error, loaderData, params 
                   values={{ correlationId: error.correlationId }}
                 />
               </li>
-            </ul>
+            </UnorderedList>
           )}
         </main>
         <footer id="wb-info" tabIndex={-1} className="mt-8 bg-stone-50 print:hidden">

--- a/frontend/app/components/lists.tsx
+++ b/frontend/app/components/lists.tsx
@@ -1,0 +1,25 @@
+import type { ComponentProps, JSX } from 'react';
+
+import { cn } from '~/utils/tailwind-utils';
+
+/**
+ * OrderedList Component
+ *
+ * A styled `<ol>` component that applies a decimal list style, spacing, and padding.
+ *
+ * @returns - A styled ordered list component.
+ */
+export function OrderedList({ className, children, ...props }: ComponentProps<'ol'>): JSX.Element {
+  return <ol className={cn('list-decimal space-y-1 pl-7', className)}>{children}</ol>;
+}
+
+/**
+ * UnorderedList Component
+ *
+ * A styled `<ul>` component that applies a disc list style, spacing, and padding.
+ *
+ * @returns - A styled unordered list component.
+ */
+export function UnorderedList({ className, children, ...props }: ComponentProps<'ol'>): JSX.Element {
+  return <ul className={cn('list-disc space-y-1 pl-7', className)}>{children}</ul>;
+}

--- a/frontend/app/routes/protected/person-case/current-name.tsx
+++ b/frontend/app/routes/protected/person-case/current-name.tsx
@@ -18,6 +18,7 @@ import { InputCheckboxes } from '~/components/input-checkboxes';
 import { InputField } from '~/components/input-field';
 import type { InputRadiosProps } from '~/components/input-radios';
 import { InputRadios } from '~/components/input-radios';
+import { UnorderedList } from '~/components/lists';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
@@ -180,7 +181,7 @@ export default function CurrentName({ loaderData, actionData, params }: Route.Co
       <FetcherErrorSummary fetcherKey={fetcherKey}>
         <fetcher.Form method="post" noValidate>
           <p className="mb-4">{t('protected:current-name.recorded-name.description')}</p>
-          <ul className="mb-8 list-disc pl-5 font-bold">
+          <UnorderedList className="mb-8 font-bold">
             <li>
               {t('protected:current-name.recorded-name.first-name')}
               <span className="ml-[1ch] font-normal">{loaderData.primaryDocName.firstName}</span>
@@ -193,7 +194,7 @@ export default function CurrentName({ loaderData, actionData, params }: Route.Co
               {t('protected:current-name.recorded-name.last-name')}
               <span className="ml-[1ch] font-normal">{loaderData.primaryDocName.lastName}</span>
             </li>
-          </ul>
+          </UnorderedList>
 
           <div className="space-y-6">
             <InputRadios

--- a/frontend/app/routes/protected/sin-application.tsx
+++ b/frontend/app/routes/protected/sin-application.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { Address } from '~/components/address';
 import { DescriptionList, DescriptionListItem } from '~/components/description-list';
 import { InlineLink } from '~/components/links';
+import { UnorderedList } from '~/components/lists';
 
 const handle = {
   i18nNamespace: ['protected'],
@@ -166,11 +167,11 @@ function PreferredNameData({ data, tabId }: PreferredNameDataProps) {
           </DescriptionListItem>
           {data.supportingDocumentsNames && data.supportingDocumentsNames.length > 0 && (
             <DescriptionListItem className="py-3" term={t('protected:current-name.supporting-docs.title')}>
-              <ul className="list-disc space-y-1 pl-7">
+              <UnorderedList>
                 {data.supportingDocumentsNames.map((name) => (
                   <li key={name}>{name}</li>
                 ))}
-              </ul>
+              </UnorderedList>
             </DescriptionListItem>
           )}
         </div>
@@ -201,11 +202,11 @@ function PersonalDetailsData({ data, tabId }: PersonalDetailsDataProps) {
       <DescriptionList className="divide-y border-y">
         <DescriptionListItem className="py-3" term={t('protected:personal-information.first-name-previously-used.label')}>
           {data.firstNamePreviouslyUsed && data.firstNamePreviouslyUsed.length > 0 && (
-            <ul className="ml-6 list-disc">
+            <UnorderedList>
               {data.firstNamePreviouslyUsed.map((value, index) => (
                 <li key={`${index}-${value}`}>{value}</li>
               ))}
-            </ul>
+            </UnorderedList>
           )}
         </DescriptionListItem>
         <DescriptionListItem className="py-3" term={t('protected:personal-information.last-name-at-birth.label')}>
@@ -213,11 +214,11 @@ function PersonalDetailsData({ data, tabId }: PersonalDetailsDataProps) {
         </DescriptionListItem>
         <DescriptionListItem className="py-3" term={t('protected:personal-information.last-name-previously-used.label')}>
           {data.lastNamePreviouslyUsed && data.lastNamePreviouslyUsed.length > 0 && (
-            <ul className="ml-6 list-disc">
+            <UnorderedList>
               {data.lastNamePreviouslyUsed.map((value, index) => (
                 <li key={`${index}-${value}`}>{value}</li>
               ))}
-            </ul>
+            </UnorderedList>
           )}
         </DescriptionListItem>
         <DescriptionListItem className="py-3" term={t('protected:personal-information.gender.label')}>

--- a/frontend/tests/components/__snapshots__/error-boundaries.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/error-boundaries.test.tsx.snap
@@ -236,7 +236,7 @@ exports[`error-boundaries > BilingualErrorBoundary > should correctly render the
             gcweb:server-error.page-message
           </p>
           <ul
-            class="list-disc pl-10 text-gray-800"
+            class="list-disc space-y-1 pl-7 text-gray-800"
           >
             <li>
               {"key":"gcweb:server-error.error-code","options":{"values":{"errorCode":"UNC-0000"}}}
@@ -274,7 +274,7 @@ exports[`error-boundaries > BilingualErrorBoundary > should correctly render the
             gcweb:server-error.page-message
           </p>
           <ul
-            class="list-disc pl-10 text-gray-800"
+            class="list-disc space-y-1 pl-7 text-gray-800"
           >
             <li>
               {"key":"gcweb:server-error.error-code","options":{"values":{"errorCode":"UNC-0000"}}}
@@ -647,7 +647,7 @@ exports[`error-boundaries > UnilingualErrorBoundary > should correctly render th
         gcweb:server-error.page-message
       </p>
       <ul
-        class="list-disc pl-10 text-gray-800"
+        class="list-disc space-y-1 pl-7 text-gray-800"
       >
         <li>
           {"key":"gcweb:server-error.error-code","options":{"values":{"errorCode":"UNC-0000"}}}

--- a/frontend/tests/components/__snapshots__/lists.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/lists.test.tsx.snap
@@ -1,0 +1,61 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`OrderedList > should render ordered list component > expected html 1`] = `
+<div>
+  <ol
+    class="list-decimal space-y-1 pl-7"
+  >
+    <li>
+      First item
+    </li>
+    <li>
+      Second item
+    </li>
+  </ol>
+</div>
+`;
+
+exports[`OrderedList > should render ordered list component with classes > expected html 1`] = `
+<div>
+  <ol
+    class="list-decimal space-y-1 pl-7 text-gray-700"
+  >
+    <li>
+      First item
+    </li>
+    <li>
+      Second item
+    </li>
+  </ol>
+</div>
+`;
+
+exports[`UnorderedList > should render unordered list component > expected html 1`] = `
+<div>
+  <ul
+    class="list-disc space-y-1 pl-7"
+  >
+    <li>
+      First item
+    </li>
+    <li>
+      Second item
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`UnorderedList > should render unordered list component with classes > expected html 1`] = `
+<div>
+  <ul
+    class="list-disc space-y-1 pl-7 text-gray-700"
+  >
+    <li>
+      First item
+    </li>
+    <li>
+      Second item
+    </li>
+  </ul>
+</div>
+`;

--- a/frontend/tests/components/lists.test.tsx
+++ b/frontend/tests/components/lists.test.tsx
@@ -1,0 +1,48 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { OrderedList, UnorderedList } from '~/components/lists';
+
+describe('OrderedList', () => {
+  it('should render ordered list component', () => {
+    const { container } = render(
+      <OrderedList id="id">
+        <li>First item</li>
+        <li>Second item</li>
+      </OrderedList>,
+    );
+    expect(container).toMatchSnapshot('expected html');
+  });
+
+  it('should render ordered list component with classes', () => {
+    const { container } = render(
+      <OrderedList id="id" className="text-gray-700">
+        <li>First item</li>
+        <li>Second item</li>
+      </OrderedList>,
+    );
+    expect(container).toMatchSnapshot('expected html');
+  });
+});
+
+describe('UnorderedList', () => {
+  it('should render unordered list component', () => {
+    const { container } = render(
+      <UnorderedList id="id">
+        <li>First item</li>
+        <li>Second item</li>
+      </UnorderedList>,
+    );
+    expect(container).toMatchSnapshot('expected html');
+  });
+
+  it('should render unordered list component with classes', () => {
+    const { container } = render(
+      <UnorderedList id="id" className="text-gray-700">
+        <li>First item</li>
+        <li>Second item</li>
+      </UnorderedList>,
+    );
+    expect(container).toMatchSnapshot('expected html');
+  });
+});


### PR DESCRIPTION
## Summary

Add `OrderdList` and `UnorderedList` reusable components to stream line lists base style in the application.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
