### PR TITLE
chore(frontend): otel tweaks

### DIFF
--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -95,8 +95,8 @@ export function handleError(error: unknown, { context, params, request }: Loader
     log.error('Uncaught error while handling request:', error);
 
     createCounter('server.errors.total').add(1, {
-      error_class: getErrorClassName(error),
-      error_code: getErrorCode(error),
+      'error.class': getErrorClassName(error),
+      'error.code': getErrorCode(error),
     });
 
     handleSpanException(error, trace.getActiveSpan());

--- a/frontend/containerfile
+++ b/frontend/containerfile
@@ -33,7 +33,7 @@ ARG BUILD_REVISION="00000000"
 ARG BUILD_VERSION="0.0.0"
 ARG IMAGE_AUTHORS="Digital Technology Solutions"
 ARG IMAGE_DESCRIPTION="Future SIR -- Frontend Application"
-ARG IMAGE_TITLE="Future SIR frontend"
+ARG IMAGE_TITLE="future-sir-frontend"
 ARG IMAGE_URL="https://github.com/DTS-STN/future-sir/"
 ARG IMAGE_VENDOR="Employment and Social Development Canada"
 


### PR DESCRIPTION
## Summary

- fix the image name in `containerfile` (this name is also used for the OpenTelemetry `service.name` dimension)
- fix the error counter's dimensions to fit more with standard dimension naming conventions
