### PR TITLE
refactor(frontend): add custom fsir data source for primary document choices

### DIFF
--- a/frontend/app/.server/domain/person-case/models.ts
+++ b/frontend/app/.server/domain/person-case/models.ts
@@ -13,11 +13,13 @@ export type ApplicantPrimaryDocumentChoice = Readonly<{
   id: string;
   nameEn: string;
   nameFr: string;
+  applicantStatusInCanadaId: string;
 }>;
 
 export type LocalizedApplicantPrimaryDocumentChoice = Readonly<{
   id: string;
   name: string;
+  applicantStatusInCanadaId: string;
 }>;
 
 export type ApplicantSecondaryDocumentChoice = Readonly<{

--- a/frontend/app/.server/domain/person-case/services/applicant-primary-document-service.ts
+++ b/frontend/app/.server/domain/person-case/services/applicant-primary-document-service.ts
@@ -2,7 +2,7 @@ import type {
   ApplicantPrimaryDocumentChoice,
   LocalizedApplicantPrimaryDocumentChoice,
 } from '~/.server/domain/person-case/models';
-import esdcApplicantPrimaryDocumentChoicesData from '~/.server/resources/esdc_applicantprimarydocumentchoices.json';
+import fsirApplicantPrimaryDocumentChoicesData from '~/.server/resources/fsir_applicantprimarydocumentchoices.json';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
 
@@ -12,10 +12,11 @@ import { ErrorCodes } from '~/errors/error-codes';
  * @returns An array of applicant primary document choice objects.
  */
 export function getApplicantPrimaryDocumentChoices(): readonly ApplicantPrimaryDocumentChoice[] {
-  return esdcApplicantPrimaryDocumentChoicesData.options.map((option) => ({
+  return fsirApplicantPrimaryDocumentChoicesData.options.map((option) => ({
     id: option.value.toString(),
     nameEn: option.labelEn,
     nameFr: option.labelFr,
+    applicantStatusInCanadaId: option.applicantStatusInCanadaValue,
   }));
 }
 
@@ -38,6 +39,25 @@ export function getApplicantPrimaryDocumentChoiceById(id: string): ApplicantPrim
 }
 
 /**
+ * Retrieves a list of applicant primary document choices by status in Canada ID.
+ *
+ * @param applicantStatusInCanadaId The ID of the status in Canada to retreive the applicant primary document choices.
+ * @returns An array of applicant primary document choice objects.
+ */
+export function getApplicantPrimaryChoicesByApplicantStatusInCanadaId(
+  applicantStatusInCanadaId: string,
+): ApplicantPrimaryDocumentChoice[] {
+  return getApplicantPrimaryDocumentChoices()
+    .filter((c) => c.applicantStatusInCanadaId === applicantStatusInCanadaId)
+    .map((option) => ({
+      id: option.id,
+      nameEn: option.nameEn,
+      nameFr: option.nameFr,
+      applicantStatusInCanadaId: option.applicantStatusInCanadaId,
+    }));
+}
+
+/**
  * Retrieves a list of applicant primary document choices localized to the specified language.
  *
  * @param language The language to localize the choice names to.
@@ -47,7 +67,28 @@ export function getLocalizedApplicantPrimaryDocumentChoices(language: Language):
   return getApplicantPrimaryDocumentChoices().map((option) => ({
     id: option.id,
     name: language === 'fr' ? option.nameFr : option.nameEn,
+    applicantStatusInCanadaId: option.applicantStatusInCanadaId,
   }));
+}
+
+/**
+ * Retrieves a list of applicant primary document choices by status in Canada ID localized to the specified language.
+ *
+ * @param applicantStatusInCanadaId The ID of the status in Canada to retreive the applicant primary document choices.
+ * @param language The language to localize the choice names to.
+ * @returns An array of localized applicant primary document choice objects.
+ */
+export function getLocalizedApplicantPrimaryDocumentChoicesByApplicantStatusInCanadaId(
+  applicantStatusInCanadaId: string,
+  language: Language,
+): LocalizedApplicantPrimaryDocumentChoice[] {
+  return getApplicantPrimaryDocumentChoices()
+    .filter((c) => c.applicantStatusInCanadaId === applicantStatusInCanadaId)
+    .map((option) => ({
+      id: option.id,
+      name: language === 'fr' ? option.nameFr : option.nameEn,
+      applicantStatusInCanadaId: option.applicantStatusInCanadaId,
+    }));
 }
 
 /**

--- a/frontend/app/.server/resources/fsir_applicantprimarydocumentchoices.json
+++ b/frontend/app/.server/resources/fsir_applicantprimarydocumentchoices.json
@@ -1,0 +1,194 @@
+{
+  "name": "fsir_applicantprimarydocumentchoices",
+  "parentOptionSetName": null,
+  "displayNameEn": "Applicant Primary Document Choices",
+  "displayNameFr": "Choix de document d'identité principal du demandeur",
+  "options": [
+    {
+      "value": 9800000000,
+      "applicantStatusInCanadaValue": "9900000000",
+      "labelEn": "Alberta birth certificate",
+      "labelFr": "Alberta birth certificate"
+    },
+    {
+      "value": 9800000001,
+      "applicantStatusInCanadaValue": "9900000000",
+      "labelEn": "British Columbia birth certificates",
+      "labelFr": "British Columbia birth certificates"
+    },
+    {
+      "value": 9800000002,
+      "applicantStatusInCanadaValue": "9900000000",
+      "labelEn": "Manitoba birth certificates",
+      "labelFr": "Manitoba birth certificates"
+    },
+    {
+      "value": 9800000003,
+      "applicantStatusInCanadaValue": "9900000000",
+      "labelEn": "New Brunswick birth certificates",
+      "labelFr": "New Brunswick birth certificates"
+    },
+    {
+      "value": 9800000004,
+      "applicantStatusInCanadaValue": "9900000000",
+      "labelEn": "Newfoundlan and Labrador birth certificates",
+      "labelFr": "Newfoundlan and Labrador birth certificates"
+    },
+    {
+      "value": 9800000005,
+      "applicantStatusInCanadaValue": "9900000000",
+      "labelEn": "Northwest Territories birth certificates",
+      "labelFr": "Northwest Territories birth certificates"
+    },
+    {
+      "value": 9800000006,
+      "applicantStatusInCanadaValue": "9900000000",
+      "labelEn": "Nunavut birth certificates",
+      "labelFr": "Nunavut birth certificates"
+    },
+    {
+      "value": 9800000007,
+      "applicantStatusInCanadaValue": "9900000000",
+      "labelEn": "Ontario birth certificates - Certified True Photostatic Print of a record of a Statement of Live Birth",
+      "labelFr": "Ontario birth certificates - Certified True Photostatic Print of a record of a Statement of Live Birth"
+    },
+    {
+      "value": 9800000008,
+      "applicantStatusInCanadaValue": "9900000000",
+      "labelEn": "Prince Edward Island birth certificates",
+      "labelFr": "Prince Edward Island birth certificates"
+    },
+    {
+      "value": 9800000009,
+      "applicantStatusInCanadaValue": "9900000000",
+      "labelEn": "Quebec birth certificates",
+      "labelFr": "Quebec birth certificates"
+    },
+    {
+      "value": 9800000010,
+      "applicantStatusInCanadaValue": "9900000000",
+      "labelEn": "Saskatchewan birth certificates",
+      "labelFr": "Saskatchewan birth certificates"
+    },
+    {
+      "value": 9800000011,
+      "applicantStatusInCanadaValue": "9900000000",
+      "labelEn": "Yukon birth certificates",
+      "labelFr": "Yukon birth certificates"
+    },
+    {
+      "value": 9800000012,
+      "applicantStatusInCanadaValue": "9900000000",
+      "labelEn": "Population List",
+      "labelFr": "Population List"
+    },
+    {
+      "value": 9800000013,
+      "applicantStatusInCanadaValue": "9900000000",
+      "labelEn": "Certificates of Canadian Citizenship",
+      "labelFr": "Certificates of Canadian Citizenship"
+    },
+    {
+      "value": 9800000014,
+      "applicantStatusInCanadaValue": "9900000001",
+      "labelEn": "Certificates of Canadian Citizenship",
+      "labelFr": "Certificates of Canadian Citizenship"
+    },
+    {
+      "value": 9800000015,
+      "applicantStatusInCanadaValue": "9900000001",
+      "labelEn": "Certificates of Registration of Birth Abroad",
+      "labelFr": "Certificates of Registration of Birth Abroad"
+    },
+    {
+      "value": 9800000016,
+      "applicantStatusInCanadaValue": "9900000002",
+      "labelEn": "Birth Certificates + Certificates of Indian Status",
+      "labelFr": "Birth Certificates + Certificates of Indian Status"
+    },
+    {
+      "value": 9800000017,
+      "applicantStatusInCanadaValue": "9900000002",
+      "labelEn": "Certificates of Canadian Citizenship + Certificates of Indian Status",
+      "labelFr": "Certificates of Canadian Citizenship + Certificates of Indian Status"
+    },
+    {
+      "value": 9800000018,
+      "applicantStatusInCanadaValue": "9900000003",
+      "labelEn": "Foreign Birth Certificates + Certificates of Indian Status",
+      "labelFr": "Foreign Birth Certificates + Certificates of Indian Status"
+    },
+    {
+      "value": 9800000019,
+      "applicantStatusInCanadaValue": "9900000003",
+      "labelEn": "Certificates of Canadian Citizenship + Certificates of Indian Status",
+      "labelFr": "Certificates of Canadian Citizenship + Certificates of Indian Status"
+    },
+    {
+      "value": 9800000020,
+      "applicantStatusInCanadaValue": "9900000004",
+      "labelEn": "Permanent Resident Card",
+      "labelFr": "Permanent Resident Card"
+    },
+    {
+      "value": 9800000021,
+      "applicantStatusInCanadaValue": "9900000004",
+      "labelEn": "Confirmation of Permanent Residence",
+      "labelFr": "Confirmation of Permanent Residence"
+    },
+    {
+      "value": 9800000022,
+      "applicantStatusInCanadaValue": "9900000004",
+      "labelEn": "Records of Landing",
+      "labelFr": "Records of Landing"
+    },
+    {
+      "value": 9800000023,
+      "applicantStatusInCanadaValue": "9900000004",
+      "labelEn": "Verification of Landing",
+      "labelFr": "Verification of Landing"
+    },
+    {
+      "value": 9800000024,
+      "applicantStatusInCanadaValue": "9900000004",
+      "labelEn": "Status Verification",
+      "labelFr": "Status Verification"
+    },
+    {
+      "value": 9800000025,
+      "applicantStatusInCanadaValue": "9900000005",
+      "labelEn": "*If only one name appears on the document, refer to Names on SIN Record (301)",
+      "labelFr": "*If only one name appears on the document, refer to Names on SIN Record (301)"
+    },
+    {
+      "value": 9800000026,
+      "applicantStatusInCanadaValue": "9900000005",
+      "labelEn": "Work Permit",
+      "labelFr": "Work Permit"
+    },
+    {
+      "value": 9800000027,
+      "applicantStatusInCanadaValue": "9900000005",
+      "labelEn": "Study Permit (indicating \"may accept employment \" or \"may work\")",
+      "labelFr": "Study Permit (indicating \"may accept employment \" or \"may work\")"
+    },
+    {
+      "value": 9800000028,
+      "applicantStatusInCanadaValue": "9900000005",
+      "labelEn": "Visitor Record (indicating authorization to work)",
+      "labelFr": "Visitor Record (indicating authorization to work)"
+    },
+    {
+      "value": 9800000029,
+      "applicantStatusInCanadaValue": "9900000005",
+      "labelEn": "Diplomatic Identity Cards + note of permission of employment",
+      "labelFr": "Diplomatic Identity Cards + note of permission of employment"
+    },
+    {
+      "value": 9800000030,
+      "applicantStatusInCanadaValue": "9900000006",
+      "labelEn": "Foreign birth certificate + letter from CPP/CRA/RRQ/OAS (for non-resident only)",
+      "labelFr": "Foreign birth certificate + letter from CPP/CRA/RRQ/OAS (for non-resident only)"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add a custom FSIR data resource: fsir_applicantprimarydocumentchoices.json. The existing esdc_applicantprimarydocumentchoices.json does not meet the needs of this POC, so we've opted to create a tailored resource instead.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
