### PR TITLE
refactor(frontend): update person-case forms for multi-channel flow

### DIFF
--- a/frontend/app/.server/locales/protected-en.json
+++ b/frontend/app/.server/locales/protected-en.json
@@ -427,6 +427,8 @@
     "page-title": "Summary",
     "case-created": "Case created",
     "id-number": "ID number",
-    "send-for-validation": "Send for validation"
+    "send-for-validation": "Send for validation",
+    "back": "Back",
+    "confirm": "Confirm"
   }
 }

--- a/frontend/app/.server/locales/protected-fr.json
+++ b/frontend/app/.server/locales/protected-fr.json
@@ -428,6 +428,8 @@
     "page-title": "Sommaire",
     "case-created": "Cas créé",
     "id-number": "Numéro d'identification",
-    "send-for-validation": "Envoyer pour validation"
+    "send-for-validation": "Envoyer pour validation",
+    "back": "Retour",
+    "confirm": "Valider"
   }
 }

--- a/frontend/app/errors/error-codes.ts
+++ b/frontend/app/errors/error-codes.ts
@@ -15,6 +15,7 @@ export const ErrorCodes = {
   // form error codes
   MISSING_TAB_ID: 'FRM-0000',
   UNRECOGNIZED_ACTION: 'FRM-0001',
+  UNRECOGNIZED_SECTION: 'FRM-0002',
 
   // i18n error codes
   NO_LANGUAGE_FOUND: 'I18N-0001',

--- a/frontend/app/i18n-routes.ts
+++ b/frontend/app/i18n-routes.ts
@@ -136,6 +136,14 @@ export const i18nRoutes = [
         },
       },
       {
+        id: 'MCF-0005',
+        file: 'routes/protected/multi-channel/edit-application.tsx',
+        paths: {
+          en: '/en/protected/multi-channel/edit-application',
+          fr: '/fr/protege/multi-chaine/edit-application',
+        },
+      },
+      {
         file: 'routes/protected/person-case/layout.tsx',
         children: [
           {
@@ -215,7 +223,7 @@ export const i18nRoutes = [
             file: 'routes/protected/person-case/previous-sin.tsx',
             paths: {
               en: '/en/protected/person-case/previous-sin',
-              fr: '/fr/protege/cas-personnel/previous-sin',
+              fr: '/fr/protege/cas-personnel/nas-precedent',
             },
           },
           {
@@ -223,7 +231,7 @@ export const i18nRoutes = [
             file: 'routes/protected/person-case/contact-information.tsx',
             paths: {
               en: '/en/protected/person-case/contact-information',
-              fr: '/fr/protege/cas-personnel/contact-information',
+              fr: '/fr/protege/cas-personnel/informations-de-contact',
             },
           },
           {

--- a/frontend/app/routes/protected/multi-channel/edit-application.tsx
+++ b/frontend/app/routes/protected/multi-channel/edit-application.tsx
@@ -1,0 +1,460 @@
+import { useId } from 'react';
+
+import type { AppLoadContext, RouteHandle } from 'react-router';
+import { data, useFetcher } from 'react-router';
+
+import { useTranslation } from 'react-i18next';
+import * as v from 'valibot';
+
+import type { Info, Route } from './+types/edit-application';
+
+import { getLocalizedApplicantGenders } from '~/.server/domain/person-case/services/applicant-gender-service';
+import { getLocalizedApplicantSecondaryDocumentChoices } from '~/.server/domain/person-case/services/applicant-secondary-document-service';
+import { getLocalizedApplicantHadSinOptions } from '~/.server/domain/person-case/services/applicant-sin-service';
+import { getLocalizedApplicantStatusInCanadaChoices } from '~/.server/domain/person-case/services/applicant-status-in-canada-service';
+import { getLocalizedApplicantSupportingDocumentType } from '~/.server/domain/person-case/services/applicant-supporting-document-service';
+import { getLocalizedApplicationSubmissionScenarios } from '~/.server/domain/person-case/services/application-submission-scenario';
+import { getLocalizedTypesOfApplicationToSubmit } from '~/.server/domain/person-case/services/application-type-service';
+import { getLocalizedLanguageOfCorrespondence } from '~/.server/domain/person-case/services/language-correspondence-service';
+import { LogFactory } from '~/.server/logging';
+import { getLocalizedCountries } from '~/.server/shared/services/country-service';
+import { getLocalizedProvinces } from '~/.server/shared/services/province-service';
+import { requireAuth } from '~/.server/utils/auth-utils';
+import { i18nRedirect } from '~/.server/utils/route-utils';
+import { Button } from '~/components/button';
+import { FetcherErrorSummary } from '~/components/error-summary';
+import { PageTitle } from '~/components/page-title';
+import { AppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
+import { HttpStatusCodes } from '~/errors/http-status-codes';
+import { getTranslation } from '~/i18n-config.server';
+import { handle as parentHandle } from '~/routes/protected/person-case/layout';
+import BirthDetailsForm from '~/routes/protected/sin-application/birth-details-form';
+import ContactInformationForm from '~/routes/protected/sin-application/contact-information-form';
+import CurrentNameForm from '~/routes/protected/sin-application/current-name-form';
+import ParentDetailsForm from '~/routes/protected/sin-application/parent-details-form';
+import PersonalInformationForm from '~/routes/protected/sin-application/personal-info-form';
+import PreviousSinForm from '~/routes/protected/sin-application/previous-sin-form';
+import PrimaryDocsForm from '~/routes/protected/sin-application/primary-docs-form';
+import RequestDetailsForm from '~/routes/protected/sin-application/request-details-form';
+import SecondaryDocForm from '~/routes/protected/sin-application/secondary-doc-form';
+import type { Errors } from '~/routes/protected/sin-application/types';
+import type {
+  birthDetailsSchema,
+  contactInformationSchema,
+  currentNameSchema,
+  parentDetailsSchema,
+  personalInfoSchema,
+  previousSinSchema,
+  primaryDocumentSchema,
+  requestDetailsSchema,
+  secondaryDocumentSchema,
+} from '~/routes/protected/sin-application/validation.server';
+import {
+  maxNumberOfParents,
+  parseBirthDetails,
+  parseContactInformation,
+  parseCurrentName,
+  parseParentDetails,
+  parsePersonalInfo,
+  parsePreviousSin,
+  parsePrimaryDocument,
+  parseRequestDetails,
+  parseSecondaryDocument,
+} from '~/routes/protected/sin-application/validation.server';
+
+const log = LogFactory.getLogger(import.meta.url);
+
+export const handle = {
+  i18nNamespace: [...parentHandle.i18nNamespace, 'protected'],
+} as const satisfies RouteHandle;
+
+export function meta({ data }: Route.MetaArgs) {
+  return [{ title: data.documentTitle }];
+}
+
+export const editSectionIds = {
+  primaryDocs: 'pri',
+  requestDetails: 'req',
+  currentName: 'cur',
+  personalInfo: 'per',
+  secondaryDoc: 'sec',
+  birthDetails: 'bir',
+  parentDetails: 'par',
+  previousSin: 'pre',
+  contactInformation: 'con',
+} as const;
+
+function getSectionId(request: Request) {
+  const sectionId = new URL(request.url).searchParams.get('section') ?? undefined;
+  const validId = Object.values(editSectionIds).some((id) => id === sectionId);
+  if (!sectionId || !validId) {
+    log.warn('Could not find the section to edit; redirecting to send validation');
+    throw i18nRedirect('routes/protected/multi-channel/send-validation.tsx', request);
+  }
+  return sectionId;
+}
+
+function getSinApplication(context: AppLoadContext, request: Request) {
+  const sinApplication = context.session.editingSinCase;
+  if (!sinApplication) {
+    log.warn('Could not find the application to edit; redirecting to send validation');
+    throw i18nRedirect('routes/protected/multi-channel/send-validation.tsx', request);
+  }
+  return sinApplication;
+}
+
+export async function action({ context, params, request }: Route.ActionArgs) {
+  requireAuth(context.session, new URL(request.url), ['user']);
+
+  const sinApplication = getSinApplication(context, request);
+  const sectionId = getSectionId(request);
+  const formData = await request.formData();
+  const action = formData.get('action');
+
+  switch (action) {
+    case 'back': {
+      throw i18nRedirect('routes/protected/multi-channel/send-validation.tsx', request);
+    }
+    case 'confirm': {
+      switch (sectionId) {
+        case editSectionIds.primaryDocs: {
+          const parseResult = parsePrimaryDocument(formData);
+          if (!parseResult.success) {
+            return data(
+              { errors: v.flatten<typeof primaryDocumentSchema>(parseResult.issues).nested },
+              { status: HttpStatusCodes.BAD_REQUEST },
+            );
+          }
+          sinApplication.primaryDocuments = parseResult.output;
+          break;
+        }
+        case editSectionIds.secondaryDoc: {
+          const parseResult = parseSecondaryDocument(formData);
+          if (!parseResult.success) {
+            return data(
+              { errors: v.flatten<typeof secondaryDocumentSchema>(parseResult.issues).nested },
+              { status: HttpStatusCodes.BAD_REQUEST },
+            );
+          }
+          sinApplication.secondaryDocument = parseResult.output;
+          break;
+        }
+        case editSectionIds.requestDetails: {
+          const parseResult = parseRequestDetails(formData);
+          if (!parseResult.success) {
+            return data(
+              { errors: v.flatten<typeof requestDetailsSchema>(parseResult.issues).nested },
+              { status: HttpStatusCodes.BAD_REQUEST },
+            );
+          }
+          sinApplication.requestDetails = parseResult.output;
+          break;
+        }
+        case editSectionIds.currentName: {
+          const parseResult = parseCurrentName(formData);
+          if (!parseResult.success) {
+            return data(
+              { errors: v.flatten<typeof currentNameSchema>(parseResult.issues).nested },
+              { status: HttpStatusCodes.BAD_REQUEST },
+            );
+          }
+          sinApplication.currentNameInfo = parseResult.output;
+          break;
+        }
+        case editSectionIds.personalInfo: {
+          const parseResult = parsePersonalInfo(formData);
+          if (!parseResult.success) {
+            return data(
+              { errors: v.flatten<typeof personalInfoSchema>(parseResult.issues).nested },
+              { status: HttpStatusCodes.BAD_REQUEST },
+            );
+          }
+          sinApplication.personalInformation = parseResult.output;
+          break;
+        }
+        case editSectionIds.birthDetails: {
+          const parseResult = parseBirthDetails(formData);
+          if (!parseResult.success) {
+            return data(
+              { errors: v.flatten<typeof birthDetailsSchema>(parseResult.issues).nested },
+              { status: HttpStatusCodes.BAD_REQUEST },
+            );
+          }
+          sinApplication.birthDetails = parseResult.output;
+          break;
+        }
+        case editSectionIds.parentDetails: {
+          const parseResult = parseParentDetails(formData);
+          if (!parseResult.success) {
+            return data(
+              { errors: v.flatten<typeof parentDetailsSchema>(parseResult.issues).nested },
+              { status: HttpStatusCodes.BAD_REQUEST },
+            );
+          }
+          sinApplication.parentDetails = parseResult.output;
+          break;
+        }
+        case editSectionIds.previousSin: {
+          const parseResult = parsePreviousSin(formData);
+          if (!parseResult.success) {
+            return data(
+              { errors: v.flatten<typeof previousSinSchema>(parseResult.issues).nested },
+              { status: HttpStatusCodes.BAD_REQUEST },
+            );
+          }
+          sinApplication.previousSin = parseResult.output;
+          break;
+        }
+        case editSectionIds.contactInformation: {
+          const parseResult = parseContactInformation(formData);
+          if (!parseResult.success) {
+            return data(
+              { errors: v.flatten<typeof contactInformationSchema>(parseResult.issues).nested },
+              { status: HttpStatusCodes.BAD_REQUEST },
+            );
+          }
+          sinApplication.contactInformation = parseResult.output;
+          break;
+        }
+        default: {
+          throw new AppError(`Unrecognized section: ${sectionId}`, ErrorCodes.UNRECOGNIZED_SECTION);
+        }
+      }
+      throw i18nRedirect('routes/protected/multi-channel/send-validation.tsx', request);
+    }
+    default: {
+      throw new AppError(`Unrecognized action: ${action}`, ErrorCodes.UNRECOGNIZED_ACTION);
+    }
+  }
+}
+
+export async function loader({ context, request }: Route.LoaderArgs) {
+  requireAuth(context.session, new URL(request.url), ['user']);
+
+  const sectionId = getSectionId(request);
+  const { t, lang } = await getTranslation(request, handle.i18nNamespace);
+  const sinApplication = getSinApplication(context, request);
+
+  switch (sectionId) {
+    case editSectionIds.primaryDocs: {
+      return {
+        sectionId,
+        documentTitle: t('protected:primary-identity-document.page-title'),
+        defaultFormValues: sinApplication.primaryDocuments,
+        localizedStatusInCanada: getLocalizedApplicantStatusInCanadaChoices(lang),
+        localizedGenders: getLocalizedApplicantGenders(lang),
+      };
+    }
+    case editSectionIds.secondaryDoc: {
+      return {
+        sectionId,
+        documentTitle: t('protected:secondary-identity-document.page-title'),
+        defaultFormValues: sinApplication.secondaryDocument,
+        localizedApplicantSecondaryDocumentChoices: getLocalizedApplicantSecondaryDocumentChoices(lang),
+      };
+    }
+    case editSectionIds.requestDetails: {
+      return {
+        sectionId,
+        documentTitle: t('protected:request-details.page-title'),
+        defaultFormValues: sinApplication.requestDetails,
+        localizedSubmissionScenarios: getLocalizedApplicationSubmissionScenarios(lang),
+        localizedTypeofApplicationToSubmit: getLocalizedTypesOfApplicationToSubmit(lang),
+      };
+    }
+    case editSectionIds.currentName: {
+      return {
+        sectionId,
+        documentTitle: t('protected:current-name.page-title'),
+        defaultFormValues: sinApplication.currentNameInfo,
+        localizedSupportingDocTypes: getLocalizedApplicantSupportingDocumentType(lang),
+        primaryDocName: {
+          firstName: sinApplication.primaryDocuments.givenName,
+          lastName: sinApplication.primaryDocuments.lastName,
+          middleName: '', // TODO: Add middle name
+        },
+      };
+    }
+    case editSectionIds.personalInfo: {
+      return {
+        sectionId,
+        documentTitle: t('protected:personal-information.page-title'),
+        primaryDocValues: sinApplication.primaryDocuments,
+        defaultFormValues: sinApplication.personalInformation,
+        genders: getLocalizedApplicantGenders(lang),
+      };
+    }
+    case editSectionIds.birthDetails: {
+      return {
+        sectionId,
+        documentTitle: t('protected:birth-details.page-title'),
+        localizedCountries: getLocalizedCountries(lang),
+        localizedProvincesTerritoriesStates: getLocalizedProvinces(lang),
+        defaultFormValues: sinApplication.birthDetails,
+      };
+    }
+    case editSectionIds.parentDetails: {
+      return {
+        sectionId,
+        documentTitle: t('protected:parent-details.page-title'),
+        localizedCountries: getLocalizedCountries(lang),
+        localizedProvincesTerritoriesStates: getLocalizedProvinces(lang),
+        maxParents: maxNumberOfParents,
+        defaultFormValues: sinApplication.parentDetails,
+      };
+    }
+    case editSectionIds.previousSin: {
+      return {
+        sectionId,
+        documentTitle: t('protected:previous-sin.page-title'),
+        defaultFormValues: sinApplication.previousSin,
+        localizedApplicantHadSinOptions: getLocalizedApplicantHadSinOptions(lang),
+      };
+    }
+    case editSectionIds.contactInformation: {
+      return {
+        sectionId,
+        documentTitle: t('protected:contact-information.page-title'),
+        defaultFormValues: sinApplication.contactInformation,
+        localizedPreferredLanguages: getLocalizedLanguageOfCorrespondence(lang),
+        localizedCountries: getLocalizedCountries(lang),
+        localizedProvincesTerritoriesStates: getLocalizedProvinces(lang),
+      };
+    }
+    default: {
+      throw new AppError(`Unrecognized section: ${sectionId}`, ErrorCodes.UNRECOGNIZED_SECTION);
+    }
+  }
+}
+
+export default function EditApplication({ loaderData, params }: Route.ComponentProps) {
+  const { t } = useTranslation(handle.i18nNamespace);
+
+  const fetcherKey = useId();
+  const fetcher = useFetcher<Info['actionData']>({ key: fetcherKey });
+  const isSubmitting = fetcher.state !== 'idle';
+  const errors = fetcher.data?.errors;
+
+  return (
+    <>
+      <PageTitle subTitle={t('protected:first-time.title')}>{loaderData.documentTitle}</PageTitle>
+      <FetcherErrorSummary fetcherKey={fetcherKey}>
+        <fetcher.Form method="post" noValidate>
+          <ApplicationForm loaderData={loaderData} errors={errors} />
+          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+            <Button name="action" value="confirm" variant="primary" id="continue-button" disabled={isSubmitting}>
+              {t('protected:send-validation.confirm')}
+            </Button>
+            <Button name="action" value="back" id="back-button" disabled={isSubmitting}>
+              {t('protected:send-validation.back')}
+            </Button>
+          </div>
+        </fetcher.Form>
+      </FetcherErrorSummary>
+    </>
+  );
+}
+
+interface ApplicationFormProps {
+  loaderData: Route.ComponentProps['loaderData'];
+  errors: Errors;
+}
+
+function ApplicationForm({ loaderData, errors }: ApplicationFormProps) {
+  switch (loaderData.sectionId) {
+    case editSectionIds.primaryDocs: {
+      return (
+        <PrimaryDocsForm
+          defaultFormValues={loaderData.defaultFormValues}
+          localizedStatusInCanada={loaderData.localizedStatusInCanada}
+          localizedGenders={loaderData.localizedGenders}
+          errors={errors}
+        />
+      );
+    }
+    case editSectionIds.secondaryDoc: {
+      return (
+        <SecondaryDocForm
+          defaultFormValues={loaderData.defaultFormValues}
+          localizedApplicantSecondaryDocumentChoices={loaderData.localizedApplicantSecondaryDocumentChoices}
+          errors={errors}
+        />
+      );
+    }
+    case editSectionIds.requestDetails: {
+      return (
+        <RequestDetailsForm
+          defaultFormValues={loaderData.defaultFormValues}
+          localizedSubmissionScenarios={loaderData.localizedSubmissionScenarios}
+          localizedTypeofApplicationToSubmit={loaderData.localizedTypeofApplicationToSubmit}
+          errors={errors}
+        />
+      );
+    }
+    case editSectionIds.currentName: {
+      return (
+        <CurrentNameForm
+          defaultFormValues={loaderData.defaultFormValues}
+          localizedSupportingDocTypes={loaderData.localizedSupportingDocTypes}
+          primaryDocName={loaderData.primaryDocName}
+          errors={errors}
+        />
+      );
+    }
+    case editSectionIds.personalInfo: {
+      return (
+        <PersonalInformationForm
+          defaultFormValues={loaderData.defaultFormValues}
+          primaryDocValues={loaderData.primaryDocValues}
+          genders={loaderData.genders}
+          errors={errors}
+        />
+      );
+    }
+    case editSectionIds.birthDetails: {
+      return (
+        <BirthDetailsForm
+          defaultFormValues={loaderData.defaultFormValues}
+          localizedCountries={loaderData.localizedCountries}
+          localizedProvincesTerritoriesStates={loaderData.localizedProvincesTerritoriesStates}
+          errors={errors}
+        />
+      );
+    }
+    case editSectionIds.parentDetails: {
+      return (
+        <ParentDetailsForm
+          defaultFormValues={loaderData.defaultFormValues}
+          localizedCountries={loaderData.localizedCountries}
+          localizedProvincesTerritoriesStates={loaderData.localizedProvincesTerritoriesStates}
+          maxParents={loaderData.maxParents}
+          errors={errors}
+        />
+      );
+    }
+    case editSectionIds.previousSin: {
+      return (
+        <PreviousSinForm
+          defaultFormValues={loaderData.defaultFormValues}
+          localizedApplicantHadSinOptions={loaderData.localizedApplicantHadSinOptions}
+          errors={errors}
+        />
+      );
+    }
+    case editSectionIds.contactInformation: {
+      return (
+        <ContactInformationForm
+          defaultFormValues={loaderData.defaultFormValues}
+          localizedPreferredLanguages={loaderData.localizedPreferredLanguages}
+          localizedCountries={loaderData.localizedCountries}
+          localizedProvincesTerritoriesStates={loaderData.localizedProvincesTerritoriesStates}
+          errors={errors}
+        />
+      );
+    }
+    default: {
+      return <></>;
+    }
+  }
+}

--- a/frontend/app/routes/protected/multi-channel/types.d.ts
+++ b/frontend/app/routes/protected/multi-channel/types.d.ts
@@ -1,0 +1,11 @@
+import 'express-session';
+
+import type { PersonSinCase } from '~/.server/domain/multi-channel/services/case-api-service';
+
+declare module 'express-session' {
+  interface SessionData {
+    editingSinCase: PersonSinCase;
+  }
+}
+
+export {};

--- a/frontend/app/routes/protected/person-case/birth-details.tsx
+++ b/frontend/app/routes/protected/person-case/birth-details.tsx
@@ -1,4 +1,4 @@
-import { useId, useState } from 'react';
+import { useId } from 'react';
 
 import type { RouteHandle } from 'react-router';
 import { data, redirect, useFetcher } from 'react-router';
@@ -15,10 +15,6 @@ import { requireAuth } from '~/.server/utils/auth-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
 import { Button } from '~/components/button';
 import { FetcherErrorSummary } from '~/components/error-summary';
-import { InputField } from '~/components/input-field';
-import type { InputRadiosProps } from '~/components/input-radios';
-import { InputRadios } from '~/components/input-radios';
-import { InputSelect } from '~/components/input-select';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
@@ -26,11 +22,9 @@ import { HttpStatusCodes } from '~/errors/http-status-codes';
 import { getTranslation } from '~/i18n-config.server';
 import { handle as parentHandle } from '~/routes/protected/person-case/layout';
 import { getStateRoute, loadMachineActor } from '~/routes/protected/person-case/state-machine.server';
-import { birthDetailsSchema } from '~/routes/protected/person-case/validation.server';
-import { getSingleKey } from '~/utils/i18n-utils';
-import { trimToUndefined } from '~/utils/string-utils';
-
-const REQUIRE_OPTIONS = { yes: 'Yes', no: 'No' } as const;
+import BirthDetailsForm from '~/routes/protected/sin-application/birth-details-form';
+import type { birthDetailsSchema } from '~/routes/protected/sin-application/validation.server';
+import { parseBirthDetails } from '~/routes/protected/sin-application/validation.server';
 
 const log = LogFactory.getLogger(import.meta.url);
 
@@ -62,14 +56,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     }
 
     case 'next': {
-      const parseResult = v.safeParse(birthDetailsSchema, {
-        country: formData.get('country') as string,
-        province: trimToUndefined(formData.get('province') as string),
-        city: trimToUndefined(formData.get('city') as string),
-        fromMultipleBirth: formData.get('from-multiple')
-          ? formData.get('from-multiple') === REQUIRE_OPTIONS.yes //
-          : undefined,
-      });
+      const parseResult = parseBirthDetails(formData);
 
       if (!parseResult.success) {
         return data(
@@ -107,42 +94,11 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
 export default function BirthDetails({ actionData, loaderData, matches, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespace);
 
-  const [country, setCountry] = useState(loaderData.defaultFormValues?.country);
-  const [fromMultipleBirth, setFromMultipleBirth] = useState(loaderData.defaultFormValues?.fromMultipleBirth);
-
   const fetcherKey = useId();
   const fetcher = useFetcher<Info['actionData']>({ key: fetcherKey });
 
   const isSubmitting = fetcher.state !== 'idle';
   const errors = fetcher.data?.errors;
-
-  const countryOptions = [{ id: 'select-option', name: '' }, ...loaderData.localizedCountries].map(({ id, name }) => ({
-    value: id === 'select-option' ? '' : id,
-    children: id === 'select-option' ? t('protected:birth-details.select-option') : name,
-  }));
-
-  const provinceTerritoryStateOptions = [
-    { id: 'select-option', name: '' },
-    ...loaderData.localizedProvincesTerritoriesStates,
-  ].map(({ id, name }) => ({
-    value: id === 'select-option' ? '' : id,
-    children: id === 'select-option' ? t('protected:contact-information.select-option') : name,
-  }));
-
-  const fromMultipleBirthOptions: InputRadiosProps['options'] = [
-    {
-      children: t('gcweb:input-option.yes'),
-      value: REQUIRE_OPTIONS.yes,
-      defaultChecked: fromMultipleBirth === true,
-      onChange: ({ target }) => setFromMultipleBirth(target.value === REQUIRE_OPTIONS.yes),
-    },
-    {
-      children: t('gcweb:input-option.no'),
-      value: REQUIRE_OPTIONS.no,
-      defaultChecked: fromMultipleBirth === false,
-      onChange: ({ target }) => setFromMultipleBirth(target.value === REQUIRE_OPTIONS.yes),
-    },
-  ];
 
   return (
     <>
@@ -150,62 +106,12 @@ export default function BirthDetails({ actionData, loaderData, matches, params }
 
       <FetcherErrorSummary fetcherKey={fetcherKey}>
         <fetcher.Form method="post" noValidate>
-          <div className="space-y-6">
-            <InputSelect
-              id="country-id"
-              name="country"
-              errorMessage={t(getSingleKey(errors?.country))}
-              defaultValue={loaderData.defaultFormValues?.country ?? ''}
-              required
-              options={countryOptions}
-              label={t('protected:birth-details.country.label')}
-              onChange={({ target }) => setCountry(target.value)}
-              className="w-full rounded-sm sm:w-104"
-            />
-            {country && (
-              <>
-                {country === globalThis.__appEnvironment.PP_CANADA_COUNTRY_CODE ? (
-                  <InputSelect
-                    className="w-max rounded-sm"
-                    id="province"
-                    label={t('protected:birth-details.province.label')}
-                    name="province"
-                    options={provinceTerritoryStateOptions}
-                    errorMessage={t(getSingleKey(errors?.province))}
-                    defaultValue={loaderData.defaultFormValues?.province}
-                    required
-                  />
-                ) : (
-                  <InputField
-                    errorMessage={t(getSingleKey(errors?.province))}
-                    label={t('protected:birth-details.province.label')}
-                    name="province"
-                    defaultValue={loaderData.defaultFormValues?.province}
-                    required={country === globalThis.__appEnvironment.PP_CANADA_COUNTRY_CODE}
-                    type="text"
-                    className="w-full rounded-sm sm:w-104"
-                  />
-                )}
-                <InputField
-                  errorMessage={t(getSingleKey(errors?.city))}
-                  label={t('protected:birth-details.city.label')}
-                  name="city"
-                  defaultValue={loaderData.defaultFormValues?.city}
-                  required={country === globalThis.__appEnvironment.PP_CANADA_COUNTRY_CODE}
-                  type="text"
-                  className="w-full rounded-sm sm:w-104"
-                />
-                <InputRadios
-                  id="from-multiple-id"
-                  legend={t('protected:birth-details.from-multiple.label')}
-                  name="from-multiple"
-                  options={fromMultipleBirthOptions}
-                  required
-                  errorMessage={t(getSingleKey(errors?.fromMultipleBirth))}
-                />
-              </>
-            )}
-          </div>
+          <BirthDetailsForm
+            defaultFormValues={loaderData.defaultFormValues}
+            localizedCountries={loaderData.localizedCountries}
+            localizedProvincesTerritoriesStates={loaderData.localizedProvincesTerritoriesStates}
+            errors={errors}
+          />
           <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
             <Button name="action" value="next" variant="primary" id="continue-button" disabled={isSubmitting}>
               {t('protected:person-case.next')}

--- a/frontend/app/routes/protected/person-case/parent-details.tsx
+++ b/frontend/app/routes/protected/person-case/parent-details.tsx
@@ -1,9 +1,8 @@
-import { useId, useState } from 'react';
+import { useId } from 'react';
 
 import type { RouteHandle } from 'react-router';
 import { data, redirect, useFetcher } from 'react-router';
 
-import { faPlus, faXmark } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import * as v from 'valibot';
 
@@ -16,9 +15,6 @@ import { requireAuth } from '~/.server/utils/auth-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
 import { Button } from '~/components/button';
 import { FetcherErrorSummary } from '~/components/error-summary';
-import { InputCheckbox } from '~/components/input-checkbox';
-import { InputField } from '~/components/input-field';
-import { InputSelect } from '~/components/input-select';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
@@ -26,9 +22,9 @@ import { HttpStatusCodes } from '~/errors/http-status-codes';
 import { getTranslation } from '~/i18n-config.server';
 import { handle as parentHandle } from '~/routes/protected/person-case/layout';
 import { getStateRoute, loadMachineActor } from '~/routes/protected/person-case/state-machine.server';
-import { maxNumberOfParents, parentDetailsSchema } from '~/routes/protected/person-case/validation.server';
-import { getSingleKey } from '~/utils/i18n-utils';
-import { trimToUndefined } from '~/utils/string-utils';
+import ParentDetailsForm from '~/routes/protected/sin-application/parent-details-form';
+import type { parentDetailsSchema } from '~/routes/protected/sin-application/validation.server';
+import { maxNumberOfParents, parseParentDetails } from '~/routes/protected/sin-application/validation.server';
 
 const log = LogFactory.getLogger(import.meta.url);
 
@@ -60,22 +56,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     }
 
     case 'next': {
-      const parentAmount = Number(formData.get('parent-amount')) || 0;
-      const inputLength = Math.min(parentAmount, maxNumberOfParents);
-
-      const parseResult = v.safeParse(
-        parentDetailsSchema,
-        Array.from({ length: inputLength }).map((_, i) => ({
-          unavailable: Boolean(formData.get(`${i}-unavailable`)),
-          givenName: String(formData.get(`${i}-given-name`)),
-          lastName: String(formData.get(`${i}-last-name`)),
-          birthLocation: {
-            country: String(formData.get(`${i}-country`)),
-            province: trimToUndefined(String(formData.get(`${i}-province`))),
-            city: trimToUndefined(String(formData.get(`${i}-city`))),
-          },
-        })),
-      );
+      const parseResult = parseParentDetails(formData);
 
       if (!parseResult.success) {
         return data(
@@ -101,29 +82,18 @@ export async function loader({ context, request }: Route.LoaderArgs) {
 
   const { lang, t } = await getTranslation(request, handle.i18nNamespace);
   const machineActor = loadMachineActor(context.session, request, 'parent-info');
-  const parentDetails = machineActor?.getSnapshot().context.parentDetails ?? [];
+  const parentDetails = machineActor?.getSnapshot().context.parentDetails;
 
   return {
     documentTitle: t('protected:parent-details.page-title'),
     localizedCountries: getLocalizedCountries(lang),
     localizedProvincesTerritoriesStates: getLocalizedProvinces(lang),
     maxParents: maxNumberOfParents,
-    defaultFormValues: parentDetails.map((details) =>
-      details.unavailable
-        ? { unavailable: true }
-        : {
-            unavailable: false,
-            givenName: details.givenName,
-            lastName: details.lastName,
-            country: details.birthLocation.country,
-            province: details.birthLocation.province,
-            city: details.birthLocation.city,
-          },
-    ),
+    defaultFormValues: parentDetails,
   };
 }
 
-export default function CreateRequest({ loaderData, actionData, params }: Route.ComponentProps) {
+export default function ParentDetails({ loaderData, actionData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespace);
 
   const fetcherKey = useId();
@@ -138,7 +108,13 @@ export default function CreateRequest({ loaderData, actionData, params }: Route.
 
       <FetcherErrorSummary fetcherKey={fetcherKey}>
         <fetcher.Form method="post" noValidate>
-          <ParentInformation errors={errors} loaderData={loaderData} />
+          <ParentDetailsForm
+            defaultFormValues={loaderData.defaultFormValues}
+            localizedCountries={loaderData.localizedCountries}
+            localizedProvincesTerritoriesStates={loaderData.localizedProvincesTerritoriesStates}
+            maxParents={loaderData.maxParents}
+            errors={errors}
+          />
           <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
             <Button name="action" value="next" variant="primary" id="continue-button" disabled={isSubmitting}>
               {t('protected:person-case.next')}
@@ -151,208 +127,4 @@ export default function CreateRequest({ loaderData, actionData, params }: Route.
       </FetcherErrorSummary>
     </>
   );
-}
-
-interface ParentInformationProps {
-  loaderData: Route.ComponentProps['loaderData'];
-  errors?: Record<string, [string, ...string[]] | undefined>;
-}
-
-function ParentInformation({ loaderData, errors }: ParentInformationProps) {
-  const { t } = useTranslation(handle.i18nNamespace);
-  const { idList, addId, removeId } = useIdList(Math.max(loaderData.defaultFormValues.length, 1));
-
-  const canAddParent = idList.length < loaderData.maxParents;
-
-  function onAddParent() {
-    if (canAddParent) addId();
-  }
-
-  function onRemoveParent(index: number) {
-    // remove parent data from the form values
-    loaderData.defaultFormValues.splice(index, 1);
-    removeId(index);
-  }
-
-  return (
-    <>
-      <input type="hidden" name="parent-amount" value={idList.length} />
-      <div className="space-y-10">
-        {idList.map((id, index) => (
-          <ParentForm
-            key={id}
-            index={index}
-            loaderData={loaderData}
-            errors={errors}
-            onRemove={idList.length > 1 ? onRemoveParent : undefined}
-          />
-        ))}
-      </div>
-      {canAddParent && (
-        <Button size="lg" type="button" variant="link" endIcon={faPlus} className="mt-3 px-3" onClick={onAddParent}>
-          {t('protected:parent-details.add-parent')}
-        </Button>
-      )}
-    </>
-  );
-}
-
-interface ParentFormProps {
-  index: number;
-  loaderData: Route.ComponentProps['loaderData'];
-  errors?: Record<string, [string, ...string[]] | undefined>;
-  onRemove?: (index: number) => void;
-}
-
-function ParentForm({ index, loaderData, errors, onRemove }: ParentFormProps) {
-  const { t } = useTranslation(handle.i18nNamespace);
-  const defaultValues = loaderData.defaultFormValues.at(index);
-
-  const [unavailable, setUnavailable] = useState(defaultValues?.unavailable);
-  const [country, setCountry] = useState(defaultValues?.country);
-
-  const countryOptions = [{ id: 'select-option', name: '' }, ...loaderData.localizedCountries].map(({ id, name }) => ({
-    value: id === 'select-option' ? '' : id,
-    children: id === 'select-option' ? t('protected:parent-details.select-option') : name,
-  }));
-
-  const provinceOptions = [{ id: 'select-option', name: '' }, ...loaderData.localizedProvincesTerritoriesStates].map(
-    ({ id, name }) => ({
-      value: id === 'select-option' ? '' : id,
-      children: id === 'select-option' ? t('protected:parent-details.select-option') : name,
-    }),
-  );
-
-  return (
-    <div className="space-y-6">
-      <div className="flex w-full items-center justify-between sm:w-150">
-        <h2 className="font-lato text-2xl font-bold">
-          {t('protected:parent-details.section-title')}
-          <span className="ml-[0.5ch]">{index + 1}</span>
-        </h2>
-        {onRemove && (
-          <Button size="lg" type="button" variant="link" endIcon={faXmark} className="px-3" onClick={() => onRemove(index)}>
-            {t('protected:parent-details.remove')}
-          </Button>
-        )}
-      </div>
-      <InputCheckbox
-        errorMessage={t(getSingleKey(errors?.[`${index}.unavailable`]))}
-        id={`${index}-unavailable-id`}
-        name={`${index}-unavailable`}
-        defaultChecked={unavailable}
-        required
-        onChange={({ target }) => setUnavailable(target.checked)}
-        labelClassName="text-lg"
-      >
-        {t('protected:parent-details.details-unavailable')}
-      </InputCheckbox>
-      {!unavailable && (
-        <>
-          <InputField
-            errorMessage={t(getSingleKey(errors?.[`${index}.givenName`]))}
-            label={t('protected:parent-details.given-name')}
-            name={`${index}-given-name`}
-            defaultValue={defaultValues?.givenName}
-            required
-            type="text"
-            className="w-full rounded-sm sm:w-104"
-          />
-          <InputField
-            errorMessage={t(getSingleKey(errors?.[`${index}.lastName`]))}
-            label={t('protected:parent-details.last-name')}
-            name={`${index}-last-name`}
-            defaultValue={defaultValues?.lastName}
-            required
-            type="text"
-            className="w-full rounded-sm sm:w-104"
-          />
-          <InputSelect
-            errorMessage={t(getSingleKey(errors?.[`${index}.birthLocation.country`]))}
-            className="w-full rounded-sm sm:w-104"
-            id={`${index}-country-id`}
-            name={`${index}-country`}
-            label={t('protected:parent-details.country')}
-            defaultValue={defaultValues?.country}
-            options={countryOptions}
-            onChange={({ target }) => setCountry(target.value)}
-          />
-          {country === globalThis.__appEnvironment.PP_CANADA_COUNTRY_CODE ? (
-            <InputSelect
-              errorMessage={t(getSingleKey(errors?.[`${index}.birthLocation.province`]))}
-              className="w-full rounded-sm sm:w-104"
-              id={`${index}-province-id`}
-              name={`${index}-province`}
-              label={t('protected:parent-details.province')}
-              required
-              defaultValue={defaultValues?.province}
-              options={provinceOptions}
-            />
-          ) : (
-            <InputField
-              errorMessage={t(getSingleKey(errors?.[`${index}.birthLocation.province`]))}
-              className="w-full rounded-sm sm:w-104"
-              label={t('protected:parent-details.province')}
-              name={`${index}-province`}
-              defaultValue={defaultValues?.province}
-              type="text"
-            />
-          )}
-          <InputField
-            errorMessage={t(getSingleKey(errors?.[`${index}.birthLocation.city`]))}
-            className="w-full rounded-sm sm:w-104"
-            label={t('protected:parent-details.city')}
-            name={`${index}-city`}
-            defaultValue={defaultValues?.city}
-            required={country === globalThis.__appEnvironment.PP_CANADA_COUNTRY_CODE}
-            type="text"
-          />
-        </>
-      )}
-    </div>
-  );
-}
-
-/**
- * A custom hook that manages a collection of unique numeric IDs.
- *
- * Useful for dynamically adding/removing form elements or list items with stable identifiers.
- *
- * @param initialSize - The initial number of IDs to generate in the collection. Must be a non-negative integer.
- *
- * @returns An object containing:
- *   - idList: An array of unique numeric IDs
- *   - addId: Function that appends a new unique ID to the list
- *   - removeId: Function that removes an ID at the specified index
- */
-function useIdList(initialSize: number) {
-  const [idList, setIdList] = useState(Array.from({ length: initialSize }, (_, index) => index + 1));
-
-  return {
-    /**
-     * The list of current ids
-     */
-    idList: idList,
-
-    /**
-     * Adds a new id to the id list
-     */
-    addId: () => {
-      setIdList((prev) => {
-        const nextId = (prev[prev.length - 1] ?? 0) + 1;
-        return [...prev, nextId];
-      });
-    },
-
-    /**
-     * Removes an id at the specified index.
-     *
-     * @param index - The index of the id to remove.
-     */
-    removeId: (index: number) => {
-      if (index < idList.length) {
-        setIdList((prev) => prev.filter((_, i) => i !== index));
-      }
-    },
-  };
 }

--- a/frontend/app/routes/protected/person-case/personal-info.tsx
+++ b/frontend/app/routes/protected/person-case/personal-info.tsx
@@ -1,11 +1,8 @@
-import { useId, useState } from 'react';
+import { useId } from 'react';
 
 import type { RouteHandle } from 'react-router';
 import { data, redirect, useFetcher } from 'react-router';
 
-import { faXmark, faXmarkCircle } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import type { ResourceKey } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import * as v from 'valibot';
 
@@ -17,8 +14,6 @@ import { requireAuth } from '~/.server/utils/auth-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
 import { Button } from '~/components/button';
 import { FetcherErrorSummary } from '~/components/error-summary';
-import { InputField } from '~/components/input-field';
-import { InputRadios } from '~/components/input-radios';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
@@ -26,9 +21,9 @@ import { HttpStatusCodes } from '~/errors/http-status-codes';
 import { getTranslation } from '~/i18n-config.server';
 import { handle as parentHandle } from '~/routes/protected/person-case/layout';
 import { getStateRoute, loadMachineActor } from '~/routes/protected/person-case/state-machine.server';
-import { personalInfoSchema } from '~/routes/protected/person-case/validation.server';
-import { getSingleKey } from '~/utils/i18n-utils';
-import { REGEX_PATTERNS } from '~/utils/regex-utils';
+import PersonalInformationForm from '~/routes/protected/sin-application/personal-info-form';
+import type { personalInfoSchema } from '~/routes/protected/sin-application/validation.server';
+import { parsePersonalInfo } from '~/routes/protected/sin-application/validation.server';
 
 const log = LogFactory.getLogger(import.meta.url);
 
@@ -60,12 +55,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     }
 
     case 'next': {
-      const parseResult = v.safeParse(personalInfoSchema, {
-        firstNamePreviouslyUsed: formData.getAll('firstNamePreviouslyUsed').map(String).filter(Boolean),
-        lastNameAtBirth: String(formData.get('lastNameAtBirth')),
-        lastNamePreviouslyUsed: formData.getAll('lastNamePreviouslyUsed').map(String).filter(Boolean),
-        gender: String(formData.get('gender')),
-      });
+      const parseResult = parsePersonalInfo(formData);
 
       if (!parseResult.success) {
         return data(
@@ -97,21 +87,9 @@ export async function loader({ context, request }: Route.LoaderArgs) {
 
   return {
     documentTitle: t('protected:personal-information.page-title'),
-    primaryDocValues: {
-      lastName: primaryDocuments?.lastName,
-      gender: primaryDocuments?.gender,
-    },
-    defaultFormValues: {
-      firstNamePreviouslyUsed: personalInformation?.firstNamePreviouslyUsed ?? [],
-      lastNameAtBirth: personalInformation?.lastNameAtBirth,
-      lastNamePreviouslyUsed: personalInformation?.lastNamePreviouslyUsed ?? [],
-      gender: personalInformation?.gender,
-    },
-    genders: getLocalizedApplicantGenders(lang).map(({ id, name }) => ({
-      value: id,
-      children: name,
-      defaultChecked: id === (personalInformation?.gender ?? primaryDocuments?.gender),
-    })),
+    primaryDocValues: primaryDocuments,
+    defaultFormValues: personalInformation,
+    genders: getLocalizedApplicantGenders(lang),
   };
 }
 
@@ -124,231 +102,18 @@ export default function PersonalInformation({ actionData, loaderData, params, ma
   const isSubmitting = fetcher.state !== 'idle';
   const errors = fetcher.data?.errors;
 
-  const [otherFirstName, setOtherFirstName] = useState('');
-  const [otherFirstNames, setOtherFirstNames] = useState(loaderData.defaultFormValues.firstNamePreviouslyUsed);
-  const [otherLastName, setOtherLastName] = useState('');
-  const [otherLastNames, setOtherLastNames] = useState(loaderData.defaultFormValues.lastNamePreviouslyUsed);
-  const [srAnnouncement, setSrAnnouncement] = useState('');
-  const [firstNameError, setFirstNameError] = useState<ResourceKey | undefined>(undefined);
-  const [lastNameError, setLastNameError] = useState<ResourceKey | undefined>(undefined);
-
-  function getErrorMessage(fieldName: string, errors?: Record<string, [string, ...string[]] | undefined>): ResourceKey {
-    if (!errors) return '';
-
-    const directError = errors[fieldName]?.[0];
-    if (directError) return directError;
-
-    const indexedErrorKey = Object.keys(errors).find((key) => key.startsWith(`${fieldName}.`));
-    return (indexedErrorKey && errors[indexedErrorKey]?.[0]) ?? '';
-  }
-
-  /**
-   * Adds a name to `otherFirstNames` if it doesn't already exist.
-   * Clears the `otherFirstName` value upon success.
-   */
-  function addOtherFirstName(): void {
-    const name = otherFirstName.trim();
-
-    const firstNameSchema = v.pipe(
-      v.string(),
-      v.trim(),
-      v.maxLength(100, 'protected:personal-information.first-name-previously-used.max-length'),
-      v.regex(REGEX_PATTERNS.NON_DIGIT, 'protected:personal-information.first-name-previously-used.format'),
-    );
-
-    const result = v.safeParse(firstNameSchema, name);
-
-    if (!result.success) {
-      setFirstNameError(result.issues[0].message);
-      return;
-    } else {
-      setFirstNameError(undefined);
-    }
-
-    if (name) {
-      setOtherFirstNames((prev) => {
-        const alreadyExists = prev.find((val) => val.toLowerCase() === name.toLowerCase());
-
-        if (alreadyExists) {
-          return prev;
-        }
-
-        setOtherFirstName('');
-        return [...prev, name];
-      });
-    }
-  }
-
-  /**
-   * Removes a name from `otherFirstNames` and announces the removal to screen readers.
-   */
-  function removeOtherFirstName(name: string): void {
-    setSrAnnouncement(t('protected:personal-information.removed-name-sr-message', { name }));
-    setOtherFirstNames((prev) => prev.filter((val) => val !== name));
-  }
-
-  /**
-   * Adds a name to `otherLastNames` if it doesn't already exist.
-   * Clears the `otherLastName` value upon success.
-   */
-  function addOtherLastName(): void {
-    const name = otherLastName.trim();
-
-    const lastNameSchema = v.pipe(
-      v.string(),
-      v.trim(),
-      v.maxLength(100, 'protected:personal-information.last-name-previously-used.max-length'),
-      v.regex(REGEX_PATTERNS.NON_DIGIT, 'protected:personal-information.last-name-previously-used.format'),
-    );
-
-    const result = v.safeParse(lastNameSchema, name);
-
-    if (!result.success) {
-      setLastNameError(result.issues[0].message);
-      return;
-    } else {
-      setLastNameError(undefined);
-    }
-
-    if (name) {
-      setOtherLastNames((prev) => {
-        const alreadyExists = prev.find((val) => val.toLowerCase() === name.toLowerCase());
-
-        if (alreadyExists) {
-          return prev;
-        }
-
-        setOtherLastName('');
-        return [...prev, name];
-      });
-    }
-  }
-
-  /**
-   * Removes a name from `otherLastNames` and announces the removal to screen readers.
-   */
-  function removeOtherLastName(name: string): void {
-    setSrAnnouncement(t('protected:personal-information.removed-name-sr-message', { name }));
-    setOtherLastNames((prev) => prev.filter((val) => val !== name));
-  }
-
   return (
     <>
       <PageTitle subTitle={t('protected:in-person.title')}>{t('protected:personal-information.page-title')}</PageTitle>
 
       <FetcherErrorSummary fetcherKey={fetcherKey}>
         <fetcher.Form method="post" noValidate={true}>
-          <div className="flex flex-col space-y-6">
-            <div id="other-first-name-input" className="flex space-x-4">
-              <InputField
-                id="first-name-id"
-                className="w-full"
-                errorMessage={t(firstNameError ?? getErrorMessage('firstNamePreviouslyUsed', errors), { maximum: 100 })}
-                helpMessagePrimary={t('protected:personal-information.first-name-previously-used.help-message-primary')}
-                label={t('protected:personal-information.first-name-previously-used.label')}
-                name="firstNamePreviouslyUsed"
-                onChange={({ target }) => setOtherFirstName(target.value)}
-                value={otherFirstName}
-              />
-              <Button
-                id="add-first-name-button"
-                className="self-end"
-                endIcon={faXmarkCircle}
-                onClick={addOtherFirstName}
-                type="button"
-                variant="link"
-              >
-                {t('protected:personal-information.add-name')}
-              </Button>
-            </div>
-
-            <div id="other-first-names" className="flex space-x-4">
-              {otherFirstNames.map((name) => (
-                <div
-                  key={name}
-                  className="inline-flex items-center justify-center rounded-sm border-blue-100 bg-blue-100 px-2 py-1 align-middle text-gray-900"
-                >
-                  <span>{name}</span>
-                  <button
-                    aria-label={t('protected:personal-information.name-added-aria-label', { name })}
-                    onClick={() => removeOtherFirstName(name)}
-                    type="button"
-                  >
-                    <FontAwesomeIcon icon={faXmark} className="ml-1" />
-                  </button>
-
-                  <input type="hidden" name="firstNamePreviouslyUsed" value={name} />
-                </div>
-              ))}
-            </div>
-
-            <InputField
-              id="last-name-at-birth-id"
-              defaultValue={loaderData.defaultFormValues.lastNameAtBirth ?? loaderData.primaryDocValues.lastName}
-              errorMessage={t(getSingleKey(errors?.lastNameAtBirth), { maximum: 100 })}
-              label={t('protected:personal-information.last-name-at-birth.label')}
-              name="lastNameAtBirth"
-              required={true}
-            />
-
-            <div id="other-last-name-input" className="flex space-x-4">
-              <InputField
-                id="last-name-id"
-                className="w-full"
-                errorMessage={t(lastNameError ?? getErrorMessage('lastNamePreviouslyUsed', errors), { maximum: 100 })}
-                helpMessagePrimary={t('protected:personal-information.last-name-previously-used.help-message-primary')}
-                label={t('protected:personal-information.last-name-previously-used.label')}
-                name="lastNamePreviouslyUsed"
-                onChange={({ target }) => setOtherLastName(target.value)}
-                value={otherLastName}
-              />
-              <Button
-                id="add-last-name-button"
-                className="self-end"
-                endIcon={faXmarkCircle}
-                onClick={addOtherLastName}
-                type="button"
-                variant="link"
-              >
-                {t('protected:personal-information.add-name')}
-              </Button>
-            </div>
-
-            <div id="other-last-names" className="flex space-x-4">
-              {otherLastNames.map((name) => (
-                <div
-                  key={name}
-                  className="inline-flex items-center justify-center rounded-sm border-blue-100 bg-blue-100 px-2 py-1 align-middle text-gray-900"
-                >
-                  <span>{name}</span>
-                  <button
-                    aria-label={t('protected:personal-information.name-added-aria-label', { name })}
-                    onClick={() => removeOtherLastName(name)}
-                    type="button"
-                  >
-                    <FontAwesomeIcon icon={faXmark} className="ml-1" />
-                  </button>
-
-                  <input type="hidden" name="lastNamePreviouslyUsed" value={name} />
-                </div>
-              ))}
-            </div>
-
-            <span aria-live="polite" aria-atomic="true" className="sr-only">
-              {srAnnouncement}
-            </span>
-
-            <InputRadios
-              id="gender-id"
-              errorMessage={t(getSingleKey(errors?.gender))}
-              helpMessagePrimary={t('protected:personal-information.gender.help-message-primary')}
-              legend={t('protected:personal-information.gender.label')}
-              name="gender"
-              options={loaderData.genders}
-              required={true}
-            />
-          </div>
-
+          <PersonalInformationForm
+            defaultFormValues={loaderData.defaultFormValues}
+            primaryDocValues={loaderData.primaryDocValues}
+            genders={loaderData.genders}
+            errors={errors}
+          />
           <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
             <Button name="action" value="next" variant="primary" id="continue-button" disabled={isSubmitting}>
               {t('protected:person-case.next')}

--- a/frontend/app/routes/protected/person-case/primary-docs.tsx
+++ b/frontend/app/routes/protected/person-case/primary-docs.tsx
@@ -1,5 +1,4 @@
-import type { JSX } from 'react';
-import { useId, useState } from 'react';
+import { useId } from 'react';
 
 import type { RouteHandle } from 'react-router';
 import { data, redirect, useFetcher } from 'react-router';
@@ -9,30 +8,23 @@ import * as v from 'valibot';
 
 import type { Info, Route } from './+types/primary-docs';
 
-import type { LocalizedApplicantGender, LocalizedApplicantStatusInCanadaChoice } from '~/.server/domain/person-case/models';
 import { getLocalizedApplicantGenders } from '~/.server/domain/person-case/services/applicant-gender-service';
 import { getLocalizedApplicantStatusInCanadaChoices } from '~/.server/domain/person-case/services/applicant-status-in-canada-service';
 import { LogFactory } from '~/.server/logging';
 import { requireAuth } from '~/.server/utils/auth-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
 import { Button } from '~/components/button';
-import { DatePickerField } from '~/components/date-picker-field';
 import { FetcherErrorSummary } from '~/components/error-summary';
-import { InputField } from '~/components/input-field';
-import { InputFile } from '~/components/input-file';
-import { InputRadios } from '~/components/input-radios';
-import { InputSelect } from '~/components/input-select';
 import { PageTitle } from '~/components/page-title';
-import { APPLICANT_STATUS_IN_CANADA } from '~/domain/constants';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
 import { HttpStatusCodes } from '~/errors/http-status-codes';
 import { getTranslation } from '~/i18n-config.server';
 import { handle as parentHandle } from '~/routes/protected/person-case/layout';
 import { getStateRoute, loadMachineActor } from '~/routes/protected/person-case/state-machine.server';
-import { primaryDocumentSchema } from '~/routes/protected/person-case/validation.server';
-import { toISODateString } from '~/utils/date-utils';
-import { getSingleKey } from '~/utils/i18n-utils';
+import PrimaryDocsForm from '~/routes/protected/sin-application/primary-docs-form';
+import type { primaryDocumentSchema } from '~/routes/protected/sin-application/validation.server';
+import { parsePrimaryDocument } from '~/routes/protected/sin-application/validation.server';
 
 const log = LogFactory.getLogger(import.meta.url);
 
@@ -64,48 +56,13 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     }
 
     case 'next': {
-      const dateOfBirthYear = formData.get('dateOfBirthYear')?.toString();
-      const dateOfBirthMonth = formData.get('dateOfBirthMonth')?.toString();
-      const dateOfBirthDay = formData.get('dateOfBirthDay')?.toString();
-
-      const citizenshipDateYear = formData.get('citizenshipDateYear')?.toString();
-      const citizenshipDateMonth = formData.get('citizenshipDateMonth')?.toString();
-      const citizenshipDateDay = formData.get('citizenshipDateDay')?.toString();
-
-      const formValues = {
-        currentStatusInCanada: formData.get('currentStatusInCanada')?.toString(),
-        documentType: formData.get('documentType')?.toString(),
-        registrationNumber: formData.get('registrationNumber')?.toString(),
-        clientNumber: formData.get('clientNumber')?.toString(),
-        givenName: formData.get('givenName')?.toString(),
-        lastName: formData.get('lastName')?.toString(),
-        gender: formData.get('gender')?.toString(),
-        dateOfBirthYear: dateOfBirthYear,
-        dateOfBirthMonth: dateOfBirthMonth,
-        dateOfBirthDay: dateOfBirthDay,
-        dateOfBirth: toDateString(dateOfBirthYear, dateOfBirthMonth, dateOfBirthDay),
-        citizenshipDateYear: citizenshipDateYear,
-        citizenshipDateMonth: citizenshipDateMonth,
-        citizenshipDateDay: citizenshipDateDay,
-        citizenshipDate: toDateString(citizenshipDateYear, citizenshipDateMonth, citizenshipDateDay),
-      };
-
-      const parseResult = v.safeParse(primaryDocumentSchema, formValues);
+      const parseResult = parsePrimaryDocument(formData);
 
       if (!parseResult.success) {
-        const formErrors = v.flatten<typeof primaryDocumentSchema>(parseResult.issues).nested;
-
-        machineActor.send({
-          type: 'setFormData',
-          data: {
-            primaryDocuments: {
-              values: formValues,
-              errors: formErrors,
-            },
-          },
-        });
-
-        return data({ formValues: formValues, formErrors: formErrors }, { status: HttpStatusCodes.BAD_REQUEST });
+        return data(
+          { errors: v.flatten<typeof primaryDocumentSchema>(parseResult.issues).nested },
+          { status: HttpStatusCodes.BAD_REQUEST },
+        );
       }
 
       machineActor.send({ type: 'submitPrimaryDocuments', data: parseResult.output });
@@ -125,14 +82,12 @@ export async function loader({ context, request }: Route.LoaderArgs) {
 
   const { lang, t } = await getTranslation(request, handle.i18nNamespace);
   const machineActor = loadMachineActor(context.session, request, 'primary-docs');
-  const machineContext = machineActor?.getSnapshot().context;
 
   return {
     documentTitle: t('protected:primary-identity-document.page-title'),
+    defaultFormValues: machineActor?.getSnapshot().context.primaryDocuments,
     localizedStatusInCanada: getLocalizedApplicantStatusInCanadaChoices(lang),
     localizedGenders: getLocalizedApplicantGenders(lang),
-    formValues: machineContext?.formData?.primaryDocuments?.values ?? machineContext?.primaryDocuments,
-    formErrors: machineContext?.formData?.primaryDocuments?.errors,
   };
 }
 
@@ -141,13 +96,9 @@ export default function PrimaryDocs({ actionData, loaderData, params }: Route.Co
 
   const fetcherKey = useId();
   const fetcher = useFetcher<Info['actionData']>({ key: fetcherKey });
+
   const isSubmitting = fetcher.state !== 'idle';
-
-  const formValues = fetcher.data?.formValues ?? loaderData.formValues;
-  const formErrors = fetcher.data?.formErrors ?? loaderData.formErrors;
-
-  const [currentStatus, setCurrentStatus] = useState(formValues?.currentStatusInCanada);
-  const [documentType, setDocumentType] = useState(formValues?.documentType);
+  const errors = fetcher.data?.errors;
 
   return (
     <>
@@ -155,31 +106,12 @@ export default function PrimaryDocs({ actionData, loaderData, params }: Route.Co
 
       <FetcherErrorSummary fetcherKey={fetcherKey}>
         <fetcher.Form method="post" noValidate encType="multipart/form-data">
-          <div className="space-y-6">
-            <CurrentStatusInCanada
-              defaultValue={formValues?.currentStatusInCanada}
-              errorMessage={t(getSingleKey(formErrors?.currentStatusInCanada))}
-              onChange={({ target }) => setCurrentStatus(target.value)}
-              statusInCanada={loaderData.localizedStatusInCanada}
-            />
-            {currentStatus && (
-              <DocumentType
-                status={currentStatus}
-                value={formValues?.documentType}
-                error={t(getSingleKey(formErrors?.documentType))}
-                onChange={({ target }) => setDocumentType(target.value)}
-              />
-            )}
-            {currentStatus && documentType && (
-              <PrimaryDocsFields
-                genders={loaderData.localizedGenders}
-                status={currentStatus}
-                formValues={formValues}
-                documentType={documentType}
-                formErrors={formErrors}
-              />
-            )}
-          </div>
+          <PrimaryDocsForm
+            defaultFormValues={loaderData.defaultFormValues}
+            localizedStatusInCanada={loaderData.localizedStatusInCanada}
+            localizedGenders={loaderData.localizedGenders}
+            errors={errors}
+          />
           <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
             <Button name="action" value="next" variant="primary" id="continue-button" disabled={isSubmitting}>
               {t('protected:person-case.next')}
@@ -192,218 +124,4 @@ export default function PrimaryDocs({ actionData, loaderData, params }: Route.Co
       </FetcherErrorSummary>
     </>
   );
-}
-
-interface CurrentStatusInCanadaProps {
-  defaultValue?: string;
-  errorMessage?: string;
-  onChange?: React.ChangeEventHandler<HTMLSelectElement>;
-  statusInCanada: LocalizedApplicantStatusInCanadaChoice[];
-}
-
-function CurrentStatusInCanada({ defaultValue, errorMessage, onChange, statusInCanada }: CurrentStatusInCanadaProps) {
-  const { t } = useTranslation(handle.i18nNamespace);
-
-  const currentStatusInCanadaOptions = [{ id: 'select-option', name: '' }, ...statusInCanada].map(({ id, name }) => ({
-    value: id === 'select-option' ? '' : id,
-    children: id === 'select-option' ? t('protected:request-details.select-option') : name,
-    disabled: id !== APPLICANT_STATUS_IN_CANADA.canadianCitizenBornOutsideCanada,
-  }));
-
-  return (
-    <>
-      <InputSelect
-        id="currentStatusInCanada"
-        name="currentStatusInCanada"
-        errorMessage={errorMessage}
-        defaultValue={defaultValue ?? ''}
-        required
-        options={currentStatusInCanadaOptions}
-        label={t('protected:primary-identity-document.current-status-in-canada.title')}
-        onChange={onChange}
-      />
-    </>
-  );
-}
-
-type DocumentTypeProps = {
-  error?: string;
-  status?: string;
-  value?: string;
-  onChange?: React.ChangeEventHandler<HTMLSelectElement>;
-};
-
-function DocumentType({ error, status, value, onChange }: DocumentTypeProps) {
-  const { t } = useTranslation(handle.i18nNamespace);
-
-  const canadianCitizenBornOutsideCanadaDocumentType = [
-    'certificate-of-canadian-citizenship',
-    'certificate-of-registration-of-birth-abroad',
-  ] as const;
-
-  const registeredIndianBornInCanadaDocumentType = [
-    'birth-certificate-and-certificate-of-indian-status',
-    'certificate-of-canadian-citizenship-and-certificate-of-indian-status',
-  ] as const;
-
-  const documentTypeOptions = [
-    {
-      children: t('protected:request-details.select-option'),
-      value: '',
-      hidden: true,
-    },
-    ...(() => {
-      switch (status) {
-        case APPLICANT_STATUS_IN_CANADA.canadianCitizenBornOutsideCanada:
-          return canadianCitizenBornOutsideCanadaDocumentType.map((value) => ({
-            value: value,
-            children: t(`protected:primary-identity-document.document-type.options.${value}` as const),
-            disabled: value !== 'certificate-of-canadian-citizenship',
-          }));
-
-        case APPLICANT_STATUS_IN_CANADA.registeredIndianBornInCanada:
-          return registeredIndianBornInCanadaDocumentType.map((value) => ({
-            value: value,
-            children: t(`protected:primary-identity-document.document-type.options.${value}` as const),
-          }));
-
-        default:
-          return [];
-      }
-    })(),
-  ];
-
-  return (
-    <>
-      {(status === APPLICANT_STATUS_IN_CANADA.canadianCitizenBornOutsideCanada ||
-        status === APPLICANT_STATUS_IN_CANADA.registeredIndianBornInCanada) && (
-        <InputSelect
-          id="documentType"
-          name="documentType"
-          errorMessage={error}
-          defaultValue={value}
-          required
-          options={documentTypeOptions}
-          label={t('protected:primary-identity-document.document-type.title')}
-          onChange={onChange}
-        />
-      )}
-    </>
-  );
-}
-
-type PrimaryDocsFieldsProps = {
-  documentType?: string;
-  formErrors?: Record<string, [string, ...string[]] | undefined>;
-  formValues?: Record<string, string | undefined>;
-  genders: LocalizedApplicantGender[];
-  status?: string;
-};
-
-function PrimaryDocsFields({ documentType, formErrors, formValues, genders, status }: PrimaryDocsFieldsProps): JSX.Element {
-  const { t } = useTranslation(handle.i18nNamespace);
-
-  const genderOptions = genders.map(({ id, name }) => ({
-    value: id,
-    children: name,
-    defaultChecked: id === formValues?.gender,
-  }));
-
-  return (
-    <>
-      {status === APPLICANT_STATUS_IN_CANADA.canadianCitizenBornOutsideCanada &&
-        documentType === 'certificate-of-canadian-citizenship' && (
-          <>
-            <InputField
-              id="registration-number-id"
-              defaultValue={formValues?.registrationNumber}
-              errorMessage={t(getSingleKey(formErrors?.registrationNumber), { length: 8 })}
-              label={t('protected:primary-identity-document.registration-number.label')}
-              name="registrationNumber"
-              required
-              type="text"
-            />
-            <InputField
-              id="client-number-id"
-              defaultValue={formValues?.clientNumber}
-              errorMessage={t(getSingleKey(formErrors?.clientNumber), { length: 10 })}
-              label={t('protected:primary-identity-document.client-number.label')}
-              name="clientNumber"
-              required
-              type="text"
-            />
-            <InputField
-              id="given-name-id"
-              defaultValue={formValues?.givenName}
-              errorMessage={t(getSingleKey(formErrors?.givenName), { maximum: 100 })}
-              helpMessagePrimary={t('protected:primary-identity-document.given-name.help-message-primary')}
-              label={t('protected:primary-identity-document.given-name.label')}
-              name="givenName"
-              required
-              type="text"
-            />
-            <InputField
-              id="last-name-id"
-              defaultValue={formValues?.lastName}
-              errorMessage={t(getSingleKey(formErrors?.lastName), { maximum: 100 })}
-              helpMessagePrimary={t('protected:primary-identity-document.last-name.help-message-primary')}
-              label={t('protected:primary-identity-document.last-name.label')}
-              name="lastName"
-              required
-              type="text"
-            />
-            <DatePickerField
-              defaultValue={formValues?.dateOfBirth ?? ''}
-              id="date-of-birth-id"
-              legend={t('protected:primary-identity-document.date-of-birth.label')}
-              required
-              names={{ day: 'dateOfBirthDay', month: 'dateOfBirthMonth', year: 'dateOfBirthYear' }}
-              errorMessages={{
-                all: t(getSingleKey(formErrors?.dateOfBirth)),
-                year: t(getSingleKey(formErrors?.dateOfBirthYear)),
-                month: t(getSingleKey(formErrors?.dateOfBirthMonth)),
-                day: t(getSingleKey(formErrors?.dateOfBirthDay)),
-              }}
-            />
-            <InputRadios
-              id="gender-id"
-              errorMessage={t(getSingleKey(formErrors?.gender))}
-              legend={t('protected:primary-identity-document.gender.label')}
-              name="gender"
-              options={genderOptions}
-              required
-            />
-            <DatePickerField
-              defaultValue={formValues?.citizenshipDate ?? ''}
-              id="citizenship-date-id"
-              legend={t('protected:primary-identity-document.citizenship-date.label')}
-              required
-              names={{ day: 'citizenshipDateDay', month: 'citizenshipDateMonth', year: 'citizenshipDateYear' }}
-              errorMessages={{
-                all: t(getSingleKey(formErrors?.citizenshipDate)),
-                year: t(getSingleKey(formErrors?.citizenshipDateYear)),
-                month: t(getSingleKey(formErrors?.citizenshipDateMonth)),
-                day: t(getSingleKey(formErrors?.citizenshipDateDay)),
-              }}
-            />
-            <InputFile
-              disabled
-              accept=".jpg,.png,.heic"
-              id="primary-document-id"
-              name="document"
-              label={t('protected:primary-identity-document.upload-document.label')}
-              required
-            />
-          </>
-        )}
-    </>
-  );
-}
-
-function toDateString(year?: string, month?: string, day?: string): string {
-  try {
-    return toISODateString(Number(year), Number(month), Number(day));
-  } catch {
-    return '';
-  }
 }

--- a/frontend/app/routes/protected/person-case/state-machine.server.ts
+++ b/frontend/app/routes/protected/person-case/state-machine.server.ts
@@ -10,11 +10,11 @@ import { ErrorCodes } from '~/errors/error-codes';
 import { HttpStatusCodes } from '~/errors/http-status-codes';
 import type { I18nRouteFile } from '~/i18n-routes';
 import { i18nRoutes } from '~/i18n-routes';
+import type { FormData } from '~/routes/protected/person-case/types';
 import type {
   BirthDetailsData,
   ContactInformationData,
   CurrentNameData,
-  FormData,
   InPersonSinApplication,
   ParentDetailsData,
   PersonalInfoData,
@@ -23,7 +23,7 @@ import type {
   PrivacyStatementData,
   RequestDetailsData,
   SecondaryDocumentData,
-} from '~/routes/protected/person-case/types';
+} from '~/routes/protected/sin-application/types';
 import { getLanguage } from '~/utils/i18n-utils';
 import { getRouteByFile } from '~/utils/route-utils';
 

--- a/frontend/app/routes/protected/person-case/types.d.ts
+++ b/frontend/app/routes/protected/person-case/types.d.ts
@@ -2,112 +2,13 @@ import 'express-session';
 import type { SnapshotFrom } from 'xstate';
 
 import type { Machine } from '~/routes/protected/person-case/state-machine.server';
+import type { InPersonSinApplication } from '~/routes/protected/sin-application/types';
 
 export type FormData = {
   [K in keyof InPersonSinApplication]?: {
     values?: Record<string, string | undefined>;
     errors?: Record<string, [string, ...string[]] | undefined>;
   };
-};
-
-export type BirthDetailsData = {
-  country: string;
-  province?: string;
-  city?: string;
-  fromMultipleBirth: boolean;
-};
-
-export type ContactInformationData = {
-  preferredLanguage: string;
-  primaryPhoneNumber: string;
-  secondaryPhoneNumber?: string;
-  emailAddress?: string;
-  country: string;
-  address: string;
-  postalCode: string;
-  city: string;
-  province: string;
-};
-
-export type CurrentNameData =
-  | { preferredSameAsDocumentName: true }
-  | {
-      preferredSameAsDocumentName: false;
-      firstName: string;
-      middleName?: string;
-      lastName: string;
-      supportingDocuments:
-        | { required: false }
-        | {
-            required: true;
-            documentTypes: string[];
-          };
-    };
-
-export type ParentDetailsData = (
-  | { unavailable: true }
-  | {
-      unavailable: false;
-      givenName: string;
-      lastName: string;
-      birthLocation: {
-        country: string;
-        province?: string;
-        city?: string;
-      };
-    }
-)[];
-
-export type PersonalInfoData = {
-  firstNamePreviouslyUsed?: string[];
-  lastNameAtBirth: string;
-  lastNamePreviouslyUsed?: string[];
-  gender: string;
-};
-
-export type PreviousSinData = {
-  hasPreviousSin: string;
-  socialInsuranceNumber?: string;
-};
-
-export type PrimaryDocumentData = {
-  citizenshipDate: string;
-  clientNumber: string;
-  currentStatusInCanada: string;
-  dateOfBirth: string;
-  documentType: string;
-  gender: string;
-  givenName: string;
-  lastName: string;
-  registrationNumber: string;
-};
-
-export type PrivacyStatementData = {
-  agreedToTerms: true;
-};
-
-export type RequestDetailsData = {
-  type: string;
-  scenario: string;
-};
-
-export type SecondaryDocumentData = {
-  documentType: string;
-  expiryMonth: number;
-  expiryYear: number;
-};
-
-export type InPersonSinApplication = {
-  birthDetails: BirthDetailsData;
-  contactInformation: ContactInformationData;
-  currentNameInfo: CurrentNameData;
-  parentDetails: ParentDetailsData;
-  personalInformation: PersonalInfoData;
-  previousSin: PreviousSinData;
-  primaryDocuments: PrimaryDocumentData;
-  privacyStatement: PrivacyStatementData;
-  requestDetails: RequestDetailsData;
-  secondaryDocument: SecondaryDocumentData;
 };
 
 declare module 'express-session' {

--- a/frontend/app/routes/protected/sin-application/application-review.tsx
+++ b/frontend/app/routes/protected/sin-application/application-review.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from 'react';
+
 import type { RouteHandle } from 'react-router';
 
 import type { ResourceKey } from 'i18next';
@@ -5,14 +7,16 @@ import { useTranslation } from 'react-i18next';
 
 import { Address } from '~/components/address';
 import { DescriptionList, DescriptionListItem } from '~/components/description-list';
-import { InlineLink } from '~/components/links';
+import type { InlineLink } from '~/components/links';
 import { UnorderedList } from '~/components/lists';
 
 const handle = {
   i18nNamespace: ['protected'],
 } as const satisfies RouteHandle;
 
-interface SinApplicationProps {
+type LinkElement = ReactElement<typeof InlineLink>;
+
+interface ApplicationReviewProps {
   inPersonSINCase: {
     primaryDocuments: DataProps['data'];
     secondaryDocument: SecondayDocumentDataProps['data'];
@@ -23,30 +27,47 @@ interface SinApplicationProps {
     previousSin: DataProps['data'];
     contactInformation: ContactInformationDataProps['data'];
   };
-  tabId?: string;
+  primaryDocumentsLink: LinkElement;
+  secondaryDocumentLink: LinkElement;
+  currentNameInfoLink: LinkElement;
+  personalInformationLink: LinkElement;
+  birthDetailsLink: LinkElement;
+  parentDetailsLink: LinkElement;
+  previousSinLink: LinkElement;
+  contactInformationLink: LinkElement;
 }
 
-export function SinApplication({ inPersonSINCase, tabId }: SinApplicationProps) {
+export function ApplicationReview({
+  inPersonSINCase,
+  primaryDocumentsLink,
+  secondaryDocumentLink,
+  currentNameInfoLink,
+  personalInformationLink,
+  birthDetailsLink,
+  parentDetailsLink,
+  previousSinLink,
+  contactInformationLink,
+}: ApplicationReviewProps) {
   return (
     <div className="mt-12 max-w-prose space-y-15">
-      <PrimaryDocumentData data={inPersonSINCase.primaryDocuments} tabId={tabId} />
-      <SecondayDocumentData data={inPersonSINCase.secondaryDocument} tabId={tabId} />
-      <PreferredNameData data={inPersonSINCase.currentNameInfo} tabId={tabId} />
-      <PersonalDetailsData data={inPersonSINCase.personalInformation} tabId={tabId} />
-      <BirthDetailsData data={inPersonSINCase.birthDetails} tabId={tabId} />
-      <ParentDetailsData data={inPersonSINCase.parentDetails} tabId={tabId} />
-      <PreviousSinData data={inPersonSINCase.previousSin} tabId={tabId} />
-      <ContactInformationData data={inPersonSINCase.contactInformation} tabId={tabId} />
+      <PrimaryDocumentData data={inPersonSINCase.primaryDocuments} link={primaryDocumentsLink} />
+      <SecondayDocumentData data={inPersonSINCase.secondaryDocument} link={secondaryDocumentLink} />
+      <PreferredNameData data={inPersonSINCase.currentNameInfo} link={currentNameInfoLink} />
+      <PersonalDetailsData data={inPersonSINCase.personalInformation} link={personalInformationLink} />
+      <BirthDetailsData data={inPersonSINCase.birthDetails} link={birthDetailsLink} />
+      <ParentDetailsData data={inPersonSINCase.parentDetails} link={parentDetailsLink} />
+      <PreviousSinData data={inPersonSINCase.previousSin} link={previousSinLink} />
+      <ContactInformationData data={inPersonSINCase.contactInformation} link={contactInformationLink} />
     </div>
   );
 }
 
 interface DataProps {
   data: Record<string, string | undefined>;
-  tabId?: string;
+  link: LinkElement;
 }
 
-function PrimaryDocumentData({ data, tabId }: DataProps) {
+function PrimaryDocumentData({ data, link }: DataProps) {
   const { t } = useTranslation(handle.i18nNamespace);
   return (
     <section className="space-y-3">
@@ -83,9 +104,7 @@ function PrimaryDocumentData({ data, tabId }: DataProps) {
           <p>{t('protected:review.choosen-file')}</p>
         </DescriptionListItem>
       </DescriptionList>
-      <InlineLink file="routes/protected/person-case/primary-docs.tsx" search={`tid=${tabId}`}>
-        {t('protected:review.edit-primary-identity-document')}
-      </InlineLink>
+      {link}
     </section>
   );
 }
@@ -97,10 +116,10 @@ interface SecondayDocumentDataProps {
     expiryMonth: number;
     expiryYear: number;
   };
-  tabId?: string;
+  link: LinkElement;
 }
 
-function SecondayDocumentData({ data, tabId }: SecondayDocumentDataProps) {
+function SecondayDocumentData({ data, link }: SecondayDocumentDataProps) {
   const { t } = useTranslation(handle.i18nNamespace);
   return (
     <section className="space-y-3">
@@ -118,9 +137,7 @@ function SecondayDocumentData({ data, tabId }: SecondayDocumentDataProps) {
           <p>{t('protected:review.choosen-file')}</p>
         </DescriptionListItem>
       </DescriptionList>
-      <InlineLink file="routes/protected/person-case/secondary-doc.tsx" search={`tid=${tabId}`}>
-        {t('protected:review.edit-secondary-identity-document')}
-      </InlineLink>
+      {link}
     </section>
   );
 }
@@ -134,10 +151,10 @@ interface PreferredNameDataProps {
     supportingDocuments?: { required: boolean; documentTypes?: string[] };
     supportingDocumentsNames?: string[];
   };
-  tabId?: string;
+  link: LinkElement;
 }
 
-function PreferredNameData({ data, tabId }: PreferredNameDataProps) {
+function PreferredNameData({ data, link }: PreferredNameDataProps) {
   const { t } = useTranslation(handle.i18nNamespace);
 
   return (
@@ -176,9 +193,7 @@ function PreferredNameData({ data, tabId }: PreferredNameDataProps) {
           )}
         </div>
       </DescriptionList>
-      <InlineLink file="routes/protected/person-case/current-name.tsx" search={`tid=${tabId}`}>
-        {t('protected:review.edit-current-name')}
-      </InlineLink>
+      {link}
     </section>
   );
 }
@@ -191,10 +206,10 @@ interface PersonalDetailsDataProps {
     gender: string;
     genderName: string;
   };
-  tabId?: string;
+  link: LinkElement;
 }
 
-function PersonalDetailsData({ data, tabId }: PersonalDetailsDataProps) {
+function PersonalDetailsData({ data, link }: PersonalDetailsDataProps) {
   const { t } = useTranslation(handle.i18nNamespace);
   return (
     <section className="space-y-3">
@@ -225,9 +240,7 @@ function PersonalDetailsData({ data, tabId }: PersonalDetailsDataProps) {
           <p>{data.genderName}</p>
         </DescriptionListItem>
       </DescriptionList>
-      <InlineLink file="routes/protected/person-case/personal-info.tsx" search={`tid=${tabId}`}>
-        {t('protected:review.edit-personal-details')}
-      </InlineLink>
+      {link}
     </section>
   );
 }
@@ -241,10 +254,10 @@ interface BirthDetailsDataProps {
     countryName: string;
     fromMultipleBirth: boolean;
   };
-  tabId?: string;
+  link: LinkElement;
 }
 
-function BirthDetailsData({ data, tabId }: BirthDetailsDataProps) {
+function BirthDetailsData({ data, link }: BirthDetailsDataProps) {
   const { t } = useTranslation(handle.i18nNamespace);
   return (
     <section className="space-y-3">
@@ -263,9 +276,7 @@ function BirthDetailsData({ data, tabId }: BirthDetailsDataProps) {
           <p>{data.fromMultipleBirth ? t('protected:review.yes') : t('protected:review.no')}</p>
         </DescriptionListItem>
       </DescriptionList>
-      <InlineLink file="routes/protected/person-case/birth-details.tsx" search={`tid=${tabId}`}>
-        {t('protected:review.edit-birth-details')}
-      </InlineLink>
+      {link}
     </section>
   );
 }
@@ -282,10 +293,10 @@ interface ParentDetailsDataProps {
       }
     | undefined
   )[];
-  tabId?: string;
+  link: LinkElement;
 }
 
-function ParentDetailsData({ data, tabId }: ParentDetailsDataProps) {
+function ParentDetailsData({ data, link }: ParentDetailsDataProps) {
   const { t } = useTranslation(handle.i18nNamespace);
   return (
     <section className="space-y-3">
@@ -328,14 +339,12 @@ function ParentDetailsData({ data, tabId }: ParentDetailsDataProps) {
             </li>
           ))}
       </ul>
-      <InlineLink file="routes/protected/person-case/parent-details.tsx" search={`tid=${tabId}`}>
-        {t('protected:review.edit-parent-details')}
-      </InlineLink>
+      {link}
     </section>
   );
 }
 
-function PreviousSinData({ data, tabId }: DataProps) {
+function PreviousSinData({ data, link }: DataProps) {
   const { t } = useTranslation(handle.i18nNamespace);
   return (
     <section className="space-y-3">
@@ -350,9 +359,7 @@ function PreviousSinData({ data, tabId }: DataProps) {
           </DescriptionListItem>
         )}
       </DescriptionList>
-      <InlineLink file="routes/protected/person-case/previous-sin.tsx" search={`tid=${tabId}`}>
-        {t('protected:review.edit-previous-sin')}
-      </InlineLink>
+      {link}
     </section>
   );
 }
@@ -372,10 +379,10 @@ interface ContactInformationDataProps {
     province: string;
     provinceName?: string;
   };
-  tabId?: string;
+  link: LinkElement;
 }
 
-function ContactInformationData({ data, tabId }: ContactInformationDataProps) {
+function ContactInformationData({ data, link }: ContactInformationDataProps) {
   const { t } = useTranslation(handle.i18nNamespace);
   return (
     <section className="space-y-3">
@@ -417,9 +424,7 @@ function ContactInformationData({ data, tabId }: ContactInformationDataProps) {
           </DescriptionListItem>
         </DescriptionList>
       </div>
-      <InlineLink file="routes/protected/person-case/contact-information.tsx" search={`tid=${tabId}`}>
-        {t('protected:review.edit-contact-information')}
-      </InlineLink>
+      {link}
     </section>
   );
 }

--- a/frontend/app/routes/protected/sin-application/birth-details-form.tsx
+++ b/frontend/app/routes/protected/sin-application/birth-details-form.tsx
@@ -1,0 +1,123 @@
+import { useState } from 'react';
+
+import type { RouteHandle } from 'react-router';
+
+import { useTranslation } from 'react-i18next';
+
+import { InputField } from '~/components/input-field';
+import type { InputRadiosProps } from '~/components/input-radios';
+import { InputRadios } from '~/components/input-radios';
+import { InputSelect } from '~/components/input-select';
+import type { BirthDetailsData, Errors, LocalizedLocations } from '~/routes/protected/sin-application/types';
+import { getSingleKey } from '~/utils/i18n-utils';
+
+const REQUIRE_OPTIONS = { yes: 'Yes', no: 'No' } as const;
+
+export const handle = {
+  i18nNamespace: ['gcweb', 'protected'],
+} as const satisfies RouteHandle;
+
+interface BirthDetailsFormProps {
+  localizedCountries: LocalizedLocations;
+  localizedProvincesTerritoriesStates: LocalizedLocations;
+  defaultFormValues: BirthDetailsData | undefined;
+  errors: Errors;
+}
+
+export default function BirthDetailsForm({
+  localizedCountries,
+  localizedProvincesTerritoriesStates,
+  defaultFormValues,
+  errors,
+}: BirthDetailsFormProps) {
+  const { t } = useTranslation(handle.i18nNamespace);
+
+  const [country, setCountry] = useState(defaultFormValues?.country);
+  const [fromMultipleBirth, setFromMultipleBirth] = useState(defaultFormValues?.fromMultipleBirth);
+
+  const countryOptions = [{ id: 'select-option', name: '' }, ...localizedCountries].map(({ id, name }) => ({
+    value: id === 'select-option' ? '' : id,
+    children: id === 'select-option' ? t('protected:birth-details.select-option') : name,
+  }));
+
+  const provinceTerritoryStateOptions = [{ id: 'select-option', name: '' }, ...localizedProvincesTerritoriesStates].map(
+    ({ id, name }) => ({
+      value: id === 'select-option' ? '' : id,
+      children: id === 'select-option' ? t('protected:contact-information.select-option') : name,
+    }),
+  );
+
+  const fromMultipleBirthOptions: InputRadiosProps['options'] = [
+    {
+      children: t('gcweb:input-option.yes'),
+      value: REQUIRE_OPTIONS.yes,
+      defaultChecked: fromMultipleBirth === true,
+      onChange: ({ target }) => setFromMultipleBirth(target.value === REQUIRE_OPTIONS.yes),
+    },
+    {
+      children: t('gcweb:input-option.no'),
+      value: REQUIRE_OPTIONS.no,
+      defaultChecked: fromMultipleBirth === false,
+      onChange: ({ target }) => setFromMultipleBirth(target.value === REQUIRE_OPTIONS.yes),
+    },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <InputSelect
+        id="country-id"
+        name="country"
+        errorMessage={t(getSingleKey(errors?.country))}
+        defaultValue={defaultFormValues?.country ?? ''}
+        required
+        options={countryOptions}
+        label={t('protected:birth-details.country.label')}
+        onChange={({ target }) => setCountry(target.value)}
+        className="w-full rounded-sm sm:w-104"
+      />
+      {country && (
+        <>
+          {country === globalThis.__appEnvironment.PP_CANADA_COUNTRY_CODE ? (
+            <InputSelect
+              className="w-max rounded-sm"
+              id="province"
+              label={t('protected:birth-details.province.label')}
+              name="province"
+              options={provinceTerritoryStateOptions}
+              errorMessage={t(getSingleKey(errors?.province))}
+              defaultValue={defaultFormValues?.province}
+              required
+            />
+          ) : (
+            <InputField
+              errorMessage={t(getSingleKey(errors?.province))}
+              label={t('protected:birth-details.province.label')}
+              name="province"
+              defaultValue={defaultFormValues?.province}
+              required={country === globalThis.__appEnvironment.PP_CANADA_COUNTRY_CODE}
+              type="text"
+              className="w-full rounded-sm sm:w-104"
+            />
+          )}
+          <InputField
+            errorMessage={t(getSingleKey(errors?.city))}
+            label={t('protected:birth-details.city.label')}
+            name="city"
+            defaultValue={defaultFormValues?.city}
+            required={country === globalThis.__appEnvironment.PP_CANADA_COUNTRY_CODE}
+            type="text"
+            className="w-full rounded-sm sm:w-104"
+          />
+          <InputRadios
+            id="from-multiple-id"
+            legend={t('protected:birth-details.from-multiple.label')}
+            name="from-multiple"
+            options={fromMultipleBirthOptions}
+            required
+            errorMessage={t(getSingleKey(errors?.fromMultipleBirth))}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/routes/protected/sin-application/contact-information-form.tsx
+++ b/frontend/app/routes/protected/sin-application/contact-information-form.tsx
@@ -1,0 +1,169 @@
+import { useState } from 'react';
+
+import type { RouteHandle } from 'react-router';
+
+import { useTranslation } from 'react-i18next';
+
+import { InputField } from '~/components/input-field';
+import { InputPhoneField } from '~/components/input-phone-field';
+import { InputRadios } from '~/components/input-radios';
+import { InputSelect } from '~/components/input-select';
+import type {
+  ContactInformationData,
+  Errors,
+  LocalizedLocations,
+  LocalizedOptions,
+} from '~/routes/protected/sin-application/types';
+import { getSingleKey } from '~/utils/i18n-utils';
+
+export const handle = {
+  i18nNamespace: ['protected'],
+} as const satisfies RouteHandle;
+
+interface ContactInformationFormProps {
+  localizedPreferredLanguages: LocalizedOptions;
+  localizedCountries: LocalizedLocations;
+  localizedProvincesTerritoriesStates: LocalizedLocations;
+  defaultFormValues: ContactInformationData | undefined;
+  errors: Errors;
+}
+
+export default function ContactInformationForm({
+  localizedPreferredLanguages,
+  localizedCountries,
+  localizedProvincesTerritoriesStates,
+  defaultFormValues,
+  errors,
+}: ContactInformationFormProps) {
+  const { t } = useTranslation(handle.i18nNamespace);
+
+  const [country, setCountry] = useState<string | undefined>(defaultFormValues?.country);
+
+  const languageOptions = localizedPreferredLanguages.map(({ id, name }) => ({
+    value: id,
+    children: name,
+    defaultChecked: id === defaultFormValues?.preferredLanguage,
+  }));
+
+  const countryOptions = [{ id: 'select-option', name: '' }, ...localizedCountries].map(({ id, name }) => ({
+    value: id === 'select-option' ? '' : id,
+    children: id === 'select-option' ? t('protected:contact-information.select-option') : name,
+  }));
+
+  const provinceTerritoryStateOptions = [{ id: 'select-option', name: '' }, ...localizedProvincesTerritoriesStates].map(
+    ({ id, name }) => ({
+      value: id === 'select-option' ? '' : id,
+      children: id === 'select-option' ? t('protected:contact-information.select-option') : name,
+    }),
+  );
+
+  return (
+    <div className="space-y-6">
+      <h2 className="font-lato text-2xl font-bold">{t('protected:contact-information.correspondence')}</h2>
+      <InputRadios
+        id="preferred-language"
+        legend={t('protected:contact-information.preferred-language-label')}
+        name="preferredLanguage"
+        options={languageOptions}
+        errorMessage={t(getSingleKey(errors?.preferredLanguage))}
+        required
+      />
+      <InputPhoneField
+        id="primary-phone-number"
+        label={t('protected:contact-information.primary-phone-label')}
+        name="primaryPhoneNumber"
+        type="tel"
+        inputMode="tel"
+        errorMessage={t(getSingleKey(errors?.primaryPhoneNumber))}
+        defaultValue={defaultFormValues?.primaryPhoneNumber}
+        required
+      />
+      <InputPhoneField
+        id="secondary-phone-number"
+        label={t('protected:contact-information.secondary-phone-label')}
+        name="secondaryPhoneNumber"
+        type="tel"
+        inputMode="tel"
+        errorMessage={t(getSingleKey(errors?.secondaryPhoneNumber))}
+        defaultValue={defaultFormValues?.secondaryPhoneNumber}
+      />
+      <div className="max-w-prose">
+        <InputField
+          id="email-address"
+          type="email"
+          inputMode="email"
+          label={t('protected:contact-information.email-label')}
+          name="emailAddress"
+          className="w-full"
+          errorMessage={t(getSingleKey(errors?.emailAddress))}
+          defaultValue={defaultFormValues?.emailAddress}
+        />
+      </div>
+      <h2 className="font-lato text-2xl font-bold">{t('protected:contact-information.mailing-address')}</h2>
+      <InputSelect
+        className="w-max rounded-sm"
+        id="country"
+        name="country"
+        label={t('protected:contact-information.country-select-label')}
+        options={countryOptions}
+        errorMessage={t(getSingleKey(errors?.country))}
+        defaultValue={defaultFormValues?.country}
+        onChange={({ target }) => setCountry(target.value)}
+        required
+      />
+      {country && (
+        <>
+          <InputField
+            id="address"
+            label={t('protected:contact-information.address-label')}
+            helpMessagePrimary={t('protected:contact-information.address-help-message')}
+            name="address"
+            className="w-full"
+            errorMessage={t(getSingleKey(errors?.address))}
+            defaultValue={defaultFormValues?.address}
+            required
+          />
+          <InputField
+            id="postal-code"
+            label={t('protected:contact-information.postal-code-label')}
+            name="postalCode"
+            errorMessage={t(getSingleKey(errors?.postalCode))}
+            defaultValue={defaultFormValues?.postalCode}
+            required
+          />
+          <InputField
+            id="city"
+            label={t('protected:contact-information.city-label')}
+            name="city"
+            className="w-full"
+            errorMessage={t(getSingleKey(errors?.city))}
+            defaultValue={defaultFormValues?.city}
+            required
+          />
+          {country === globalThis.__appEnvironment.PP_CANADA_COUNTRY_CODE ? (
+            <InputSelect
+              className="w-max rounded-sm"
+              id="province"
+              label={t('protected:contact-information.canada-province-label')}
+              name="province"
+              options={provinceTerritoryStateOptions}
+              errorMessage={t(getSingleKey(errors?.province))}
+              defaultValue={defaultFormValues?.province}
+              required
+            />
+          ) : (
+            <InputField
+              id="province"
+              label={t('protected:contact-information.other-country-province-label')}
+              name="province"
+              className="w-full"
+              errorMessage={t(getSingleKey(errors?.province))}
+              defaultValue={defaultFormValues?.province}
+              required
+            />
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/routes/protected/sin-application/current-name-form.tsx
+++ b/frontend/app/routes/protected/sin-application/current-name-form.tsx
@@ -1,0 +1,176 @@
+import { useState } from 'react';
+
+import type { RouteHandle } from 'react-router';
+
+import { useTranslation } from 'react-i18next';
+
+import { InputCheckboxes } from '~/components/input-checkboxes';
+import { InputField } from '~/components/input-field';
+import type { InputRadiosProps } from '~/components/input-radios';
+import { InputRadios } from '~/components/input-radios';
+import { UnorderedList } from '~/components/lists';
+import type { CurrentNameData, Errors, LocalizedOptions } from '~/routes/protected/sin-application/types';
+import { getSingleKey } from '~/utils/i18n-utils';
+
+const REQUIRE_OPTIONS = { yes: 'Yes', no: 'No' } as const;
+
+export const handle = {
+  i18nNamespace: ['gcweb', 'protected'],
+} as const satisfies RouteHandle;
+
+interface CurrentNameFormProps {
+  localizedSupportingDocTypes: LocalizedOptions;
+  primaryDocName: {
+    firstName?: string;
+    lastName?: string;
+    middleName?: string;
+  };
+  defaultFormValues: CurrentNameData | undefined;
+  errors: Errors;
+}
+
+export default function CurrentNameForm({
+  localizedSupportingDocTypes,
+  primaryDocName,
+  defaultFormValues,
+  errors,
+}: CurrentNameFormProps) {
+  const { t } = useTranslation(handle.i18nNamespace);
+
+  const [sameName, setSameName] = useState(defaultFormValues?.preferredSameAsDocumentName);
+  const [requireDoc, setRequireDoc] = useState(
+    defaultFormValues && defaultFormValues.preferredSameAsDocumentName === false
+      ? defaultFormValues.supportingDocuments.required
+      : false,
+  );
+
+  const nameOptions: InputRadiosProps['options'] = [
+    {
+      children: t('gcweb:input-option.yes'),
+      value: REQUIRE_OPTIONS.yes,
+      defaultChecked: sameName === true,
+      onChange: ({ target }) => setSameName(target.value === REQUIRE_OPTIONS.yes),
+    },
+    {
+      children: t('gcweb:input-option.no'),
+      value: REQUIRE_OPTIONS.no,
+      defaultChecked: sameName === false,
+      onChange: ({ target }) => setSameName(target.value === REQUIRE_OPTIONS.yes),
+    },
+  ];
+
+  const requireOptions: InputRadiosProps['options'] = [
+    {
+      children: t('gcweb:input-option.yes'),
+      value: REQUIRE_OPTIONS.yes,
+      defaultChecked: requireDoc === true,
+      onChange: ({ target }) => setRequireDoc(target.value === REQUIRE_OPTIONS.yes),
+    },
+    {
+      children: t('gcweb:input-option.no'),
+      value: REQUIRE_OPTIONS.no,
+      defaultChecked: requireDoc === false,
+      onChange: ({ target }) => setRequireDoc(target.value === REQUIRE_OPTIONS.yes),
+    },
+  ];
+
+  const docTypes = localizedSupportingDocTypes.map((doc) => ({
+    value: doc.id,
+    children: doc.name,
+    defaultChecked:
+      defaultFormValues &&
+      defaultFormValues.preferredSameAsDocumentName === false &&
+      defaultFormValues.supportingDocuments.required === true
+        ? defaultFormValues.supportingDocuments.documentTypes.includes(doc.id)
+        : false,
+  }));
+
+  return (
+    <>
+      <p className="mb-4">{t('protected:current-name.recorded-name.description')}</p>
+      <UnorderedList className="mb-8 font-bold">
+        <li>
+          {t('protected:current-name.recorded-name.first-name')}
+          <span className="ml-[1ch] font-normal">{primaryDocName.firstName}</span>
+        </li>
+        <li>
+          {t('protected:current-name.recorded-name.middle-name')}
+          <span className="ml-[1ch] font-normal">{primaryDocName.middleName}</span>
+        </li>
+        <li>
+          {t('protected:current-name.recorded-name.last-name')}
+          <span className="ml-[1ch] font-normal">{primaryDocName.lastName}</span>
+        </li>
+      </UnorderedList>
+
+      <div className="space-y-6">
+        <InputRadios
+          errorMessage={t(getSingleKey(errors?.preferredSameAsDocumentName))}
+          id="same-name-id"
+          legend={t('protected:current-name.preferred-name.description')}
+          name="same-name"
+          options={nameOptions}
+          required
+        />
+        {sameName === false && (
+          <>
+            <InputField
+              errorMessage={t(getSingleKey(errors?.firstName), { maximum: 100 })}
+              label={t('protected:current-name.preferred-name.first-name')}
+              name="first-name"
+              defaultValue={
+                defaultFormValues && defaultFormValues.preferredSameAsDocumentName === false ? defaultFormValues.firstName : ''
+              }
+              required
+              type="text"
+              className="w-full rounded-sm sm:w-104"
+            />
+            <InputField
+              errorMessage={t(getSingleKey(errors?.middleName), { maximum: 100 })}
+              label={t('protected:current-name.preferred-name.middle-name')}
+              name="middle-name"
+              defaultValue={
+                defaultFormValues && defaultFormValues.preferredSameAsDocumentName === false
+                  ? (defaultFormValues.middleName ?? '')
+                  : ''
+              }
+              type="text"
+              className="w-full rounded-sm sm:w-104"
+            />
+            <InputField
+              errorMessage={t(getSingleKey(errors?.lastName), { maximum: 100 })}
+              label={t('protected:current-name.preferred-name.last-name')}
+              name="last-name"
+              defaultValue={
+                defaultFormValues && defaultFormValues.preferredSameAsDocumentName === false ? defaultFormValues.lastName : ''
+              }
+              required
+              type="text"
+              className="w-full rounded-sm sm:w-104"
+            />
+            <h2 className="font-lato mt-12 text-2xl font-bold">{t('protected:current-name.supporting-docs.title')}</h2>
+            <p>{t('protected:current-name.supporting-docs.description')}</p>
+            <InputRadios
+              id="docs-required-id"
+              errorMessage={t(getSingleKey(errors?.['supportingDocuments.required']))}
+              legend={t('protected:current-name.supporting-docs.docs-required')}
+              name="docs-required"
+              options={requireOptions}
+              required
+            />
+            {requireDoc && (
+              <InputCheckboxes
+                id="doc-type-id"
+                errorMessage={t(getSingleKey(errors?.['supportingDocuments.documentTypes']))}
+                legend={t('protected:current-name.supporting-docs.doc-type')}
+                name="doc-type"
+                options={docTypes}
+                required
+              />
+            )}
+          </>
+        )}
+      </div>
+    </>
+  );
+}

--- a/frontend/app/routes/protected/sin-application/parent-details-form.tsx
+++ b/frontend/app/routes/protected/sin-application/parent-details-form.tsx
@@ -1,0 +1,239 @@
+import { useState } from 'react';
+
+import type { RouteHandle } from 'react-router';
+
+import { faPlus, faXmark } from '@fortawesome/free-solid-svg-icons';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '~/components/button';
+import { InputCheckbox } from '~/components/input-checkbox';
+import { InputField } from '~/components/input-field';
+import { InputSelect } from '~/components/input-select';
+import type { Errors, LocalizedLocations, ParentDetailsData } from '~/routes/protected/sin-application/types';
+import { getSingleKey } from '~/utils/i18n-utils';
+
+export const handle = {
+  i18nNamespace: ['protected'],
+} as const satisfies RouteHandle;
+
+interface ParentDetailsFormProps {
+  defaultFormValues: ParentDetailsData | undefined;
+  localizedCountries: LocalizedLocations;
+  localizedProvincesTerritoriesStates: LocalizedLocations;
+  maxParents: number;
+  errors: Errors;
+}
+
+export default function ParentDetailsForm({
+  defaultFormValues = [],
+  localizedCountries,
+  localizedProvincesTerritoriesStates,
+  maxParents,
+  errors,
+}: ParentDetailsFormProps) {
+  const { t } = useTranslation(handle.i18nNamespace);
+  const { idList, addId, removeId } = useIdList(Math.max(defaultFormValues.length, 1));
+
+  const canAddParent = idList.length < maxParents;
+
+  function onAddParent() {
+    if (canAddParent) addId();
+  }
+
+  function onRemoveParent(index: number) {
+    // remove parent data from the form values
+    defaultFormValues.splice(index, 1);
+    removeId(index);
+  }
+
+  return (
+    <>
+      <input type="hidden" name="parent-amount" value={idList.length} />
+      <div className="space-y-10">
+        {idList.map((id, index) => (
+          <ParentForm
+            key={id}
+            index={index}
+            defaultFormValues={defaultFormValues}
+            localizedCountries={localizedCountries}
+            localizedProvincesTerritoriesStates={localizedProvincesTerritoriesStates}
+            errors={errors}
+            onRemove={idList.length > 1 ? onRemoveParent : undefined}
+          />
+        ))}
+      </div>
+      {canAddParent && (
+        <Button size="lg" type="button" variant="link" endIcon={faPlus} className="mt-3 px-3" onClick={onAddParent}>
+          {t('protected:parent-details.add-parent')}
+        </Button>
+      )}
+    </>
+  );
+}
+
+interface ParentFormProps {
+  index: number;
+  defaultFormValues: ParentDetailsData;
+  localizedCountries: LocalizedLocations;
+  localizedProvincesTerritoriesStates: LocalizedLocations;
+  errors: Errors;
+  onRemove?: (index: number) => void;
+}
+
+function ParentForm({
+  index,
+  defaultFormValues,
+  localizedCountries,
+  localizedProvincesTerritoriesStates,
+  errors,
+  onRemove,
+}: ParentFormProps) {
+  const { t } = useTranslation(handle.i18nNamespace);
+  const defaultValues = defaultFormValues.at(index);
+  const defaultParentAvailable = defaultValues?.unavailable === false;
+  const [unavailable, setUnavailable] = useState(defaultValues?.unavailable);
+  const [country, setCountry] = useState(defaultParentAvailable ? defaultValues.birthLocation.country : undefined);
+
+  const countryOptions = [{ id: 'select-option', name: '' }, ...localizedCountries].map(({ id, name }) => ({
+    value: id === 'select-option' ? '' : id,
+    children: id === 'select-option' ? t('protected:parent-details.select-option') : name,
+  }));
+
+  const provinceOptions = [{ id: 'select-option', name: '' }, ...localizedProvincesTerritoriesStates].map(({ id, name }) => ({
+    value: id === 'select-option' ? '' : id,
+    children: id === 'select-option' ? t('protected:parent-details.select-option') : name,
+  }));
+
+  return (
+    <div className="space-y-6">
+      <div className="flex w-full items-center justify-between sm:w-150">
+        <h2 className="font-lato text-2xl font-bold">
+          {t('protected:parent-details.section-title')}
+          <span className="ml-[0.5ch]">{index + 1}</span>
+        </h2>
+        {onRemove && (
+          <Button size="lg" type="button" variant="link" endIcon={faXmark} className="px-3" onClick={() => onRemove(index)}>
+            {t('protected:parent-details.remove')}
+          </Button>
+        )}
+      </div>
+      <InputCheckbox
+        errorMessage={t(getSingleKey(errors?.[`${index}.unavailable`]))}
+        id={`${index}-unavailable-id`}
+        name={`${index}-unavailable`}
+        defaultChecked={unavailable}
+        required
+        onChange={({ target }) => setUnavailable(target.checked)}
+        labelClassName="text-lg"
+      >
+        {t('protected:parent-details.details-unavailable')}
+      </InputCheckbox>
+      {!unavailable && (
+        <>
+          <InputField
+            errorMessage={t(getSingleKey(errors?.[`${index}.givenName`]))}
+            label={t('protected:parent-details.given-name')}
+            name={`${index}-given-name`}
+            defaultValue={defaultParentAvailable ? defaultValues.givenName : undefined}
+            required
+            type="text"
+            className="w-full rounded-sm sm:w-104"
+          />
+          <InputField
+            errorMessage={t(getSingleKey(errors?.[`${index}.lastName`]))}
+            label={t('protected:parent-details.last-name')}
+            name={`${index}-last-name`}
+            defaultValue={defaultParentAvailable ? defaultValues.lastName : undefined}
+            required
+            type="text"
+            className="w-full rounded-sm sm:w-104"
+          />
+          <InputSelect
+            errorMessage={t(getSingleKey(errors?.[`${index}.birthLocation.country`]))}
+            className="w-full rounded-sm sm:w-104"
+            id={`${index}-country-id`}
+            name={`${index}-country`}
+            label={t('protected:parent-details.country')}
+            defaultValue={defaultParentAvailable ? defaultValues.birthLocation.country : undefined}
+            options={countryOptions}
+            onChange={({ target }) => setCountry(target.value)}
+          />
+          {country === globalThis.__appEnvironment.PP_CANADA_COUNTRY_CODE ? (
+            <InputSelect
+              errorMessage={t(getSingleKey(errors?.[`${index}.birthLocation.province`]))}
+              className="w-full rounded-sm sm:w-104"
+              id={`${index}-province-id`}
+              name={`${index}-province`}
+              label={t('protected:parent-details.province')}
+              required
+              defaultValue={defaultParentAvailable ? defaultValues.birthLocation.province : undefined}
+              options={provinceOptions}
+            />
+          ) : (
+            <InputField
+              errorMessage={t(getSingleKey(errors?.[`${index}.birthLocation.province`]))}
+              className="w-full rounded-sm sm:w-104"
+              label={t('protected:parent-details.province')}
+              name={`${index}-province`}
+              defaultValue={defaultParentAvailable ? defaultValues.birthLocation.province : undefined}
+              type="text"
+            />
+          )}
+          <InputField
+            errorMessage={t(getSingleKey(errors?.[`${index}.birthLocation.city`]))}
+            className="w-full rounded-sm sm:w-104"
+            label={t('protected:parent-details.city')}
+            name={`${index}-city`}
+            defaultValue={defaultParentAvailable ? defaultValues.birthLocation.city : undefined}
+            required={country === globalThis.__appEnvironment.PP_CANADA_COUNTRY_CODE}
+            type="text"
+          />
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * A custom hook that manages a collection of unique numeric IDs.
+ *
+ * Useful for dynamically adding/removing form elements or list items with stable identifiers.
+ *
+ * @param initialSize - The initial number of IDs to generate in the collection. Must be a non-negative integer.
+ *
+ * @returns An object containing:
+ *   - idList: An array of unique numeric IDs
+ *   - addId: Function that appends a new unique ID to the list
+ *   - removeId: Function that removes an ID at the specified index
+ */
+function useIdList(initialSize: number) {
+  const [idList, setIdList] = useState(Array.from({ length: initialSize }, (_, index) => index + 1));
+
+  return {
+    /**
+     * The list of current ids
+     */
+    idList: idList,
+
+    /**
+     * Adds a new id to the id list
+     */
+    addId: () => {
+      setIdList((prev) => {
+        const nextId = (prev[prev.length - 1] ?? 0) + 1;
+        return [...prev, nextId];
+      });
+    },
+
+    /**
+     * Removes an id at the specified index.
+     *
+     * @param index - The index of the id to remove.
+     */
+    removeId: (index: number) => {
+      if (index < idList.length) {
+        setIdList((prev) => prev.filter((_, i) => i !== index));
+      }
+    },
+  };
+}

--- a/frontend/app/routes/protected/sin-application/personal-info-form.tsx
+++ b/frontend/app/routes/protected/sin-application/personal-info-form.tsx
@@ -1,0 +1,263 @@
+import { useState } from 'react';
+
+import type { RouteHandle } from 'react-router';
+
+import { faXmark, faXmarkCircle } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import type { ResourceKey } from 'i18next';
+import { useTranslation } from 'react-i18next';
+import * as v from 'valibot';
+
+import { Button } from '~/components/button';
+import { InputField } from '~/components/input-field';
+import { InputRadios } from '~/components/input-radios';
+import { handle as parentHandle } from '~/routes/protected/person-case/layout';
+import type { Errors, LocalizedOptions, PersonalInfoData, PrimaryDocumentData } from '~/routes/protected/sin-application/types';
+import { getSingleKey } from '~/utils/i18n-utils';
+import { REGEX_PATTERNS } from '~/utils/regex-utils';
+
+export const handle = {
+  i18nNamespace: [...parentHandle.i18nNamespace, 'protected'],
+} as const satisfies RouteHandle;
+
+interface PersonalInformationFormProps {
+  defaultFormValues: PersonalInfoData | undefined;
+  primaryDocValues: PrimaryDocumentData | undefined;
+  genders: LocalizedOptions;
+  errors: Errors;
+}
+
+export default function PersonalInformationForm({
+  defaultFormValues,
+  primaryDocValues,
+  genders,
+  errors,
+}: PersonalInformationFormProps) {
+  const { t } = useTranslation(handle.i18nNamespace);
+
+  const [otherFirstName, setOtherFirstName] = useState('');
+  const [otherFirstNames, setOtherFirstNames] = useState(defaultFormValues?.firstNamePreviouslyUsed ?? []);
+  const [otherLastName, setOtherLastName] = useState('');
+  const [otherLastNames, setOtherLastNames] = useState(defaultFormValues?.lastNamePreviouslyUsed ?? []);
+  const [srAnnouncement, setSrAnnouncement] = useState('');
+  const [firstNameError, setFirstNameError] = useState<ResourceKey | undefined>(undefined);
+  const [lastNameError, setLastNameError] = useState<ResourceKey | undefined>(undefined);
+  const genderOptions = genders.map(({ id, name }) => ({
+    value: id,
+    children: name,
+    defaultChecked: id === (defaultFormValues?.gender ?? primaryDocValues?.gender),
+  }));
+
+  function getErrorMessage(fieldName: string, errors?: Record<string, [string, ...string[]] | undefined>): ResourceKey {
+    if (!errors) return '';
+
+    const directError = errors[fieldName]?.[0];
+    if (directError) return directError;
+
+    const indexedErrorKey = Object.keys(errors).find((key) => key.startsWith(`${fieldName}.`));
+    return (indexedErrorKey && errors[indexedErrorKey]?.[0]) ?? '';
+  }
+
+  /**
+   * Adds a name to `otherFirstNames` if it doesn't already exist.
+   * Clears the `otherFirstName` value upon success.
+   */
+  function addOtherFirstName(): void {
+    const name = otherFirstName.trim();
+
+    const firstNameSchema = v.pipe(
+      v.string(),
+      v.trim(),
+      v.maxLength(100, 'protected:personal-information.first-name-previously-used.max-length'),
+      v.regex(REGEX_PATTERNS.NON_DIGIT, 'protected:personal-information.first-name-previously-used.format'),
+    );
+
+    const result = v.safeParse(firstNameSchema, name);
+
+    if (!result.success) {
+      setFirstNameError(result.issues[0].message);
+      return;
+    } else {
+      setFirstNameError(undefined);
+    }
+
+    if (name) {
+      setOtherFirstNames((prev) => {
+        const alreadyExists = prev.find((val) => val.toLowerCase() === name.toLowerCase());
+
+        if (alreadyExists) {
+          return prev;
+        }
+
+        setOtherFirstName('');
+        return [...prev, name];
+      });
+    }
+  }
+
+  /**
+   * Removes a name from `otherFirstNames` and announces the removal to screen readers.
+   */
+  function removeOtherFirstName(name: string): void {
+    setSrAnnouncement(t('protected:personal-information.removed-name-sr-message', { name }));
+    setOtherFirstNames((prev) => prev.filter((val) => val !== name));
+  }
+
+  /**
+   * Adds a name to `otherLastNames` if it doesn't already exist.
+   * Clears the `otherLastName` value upon success.
+   */
+  function addOtherLastName(): void {
+    const name = otherLastName.trim();
+
+    const lastNameSchema = v.pipe(
+      v.string(),
+      v.trim(),
+      v.maxLength(100, 'protected:personal-information.last-name-previously-used.max-length'),
+      v.regex(REGEX_PATTERNS.NON_DIGIT, 'protected:personal-information.last-name-previously-used.format'),
+    );
+
+    const result = v.safeParse(lastNameSchema, name);
+
+    if (!result.success) {
+      setLastNameError(result.issues[0].message);
+      return;
+    } else {
+      setLastNameError(undefined);
+    }
+
+    if (name) {
+      setOtherLastNames((prev) => {
+        const alreadyExists = prev.find((val) => val.toLowerCase() === name.toLowerCase());
+
+        if (alreadyExists) {
+          return prev;
+        }
+
+        setOtherLastName('');
+        return [...prev, name];
+      });
+    }
+  }
+
+  /**
+   * Removes a name from `otherLastNames` and announces the removal to screen readers.
+   */
+  function removeOtherLastName(name: string): void {
+    setSrAnnouncement(t('protected:personal-information.removed-name-sr-message', { name }));
+    setOtherLastNames((prev) => prev.filter((val) => val !== name));
+  }
+
+  return (
+    <div className="flex flex-col space-y-6">
+      <div id="other-first-name-input" className="flex space-x-4">
+        <InputField
+          id="first-name-id"
+          className="w-full"
+          errorMessage={t(firstNameError ?? getErrorMessage('firstNamePreviouslyUsed', errors), { maximum: 100 })}
+          helpMessagePrimary={t('protected:personal-information.first-name-previously-used.help-message-primary')}
+          label={t('protected:personal-information.first-name-previously-used.label')}
+          name="firstNamePreviouslyUsed"
+          onChange={({ target }) => setOtherFirstName(target.value)}
+          value={otherFirstName}
+        />
+        <Button
+          id="add-first-name-button"
+          className="self-end"
+          endIcon={faXmarkCircle}
+          onClick={addOtherFirstName}
+          type="button"
+          variant="link"
+        >
+          {t('protected:personal-information.add-name')}
+        </Button>
+      </div>
+
+      <div id="other-first-names" className="flex space-x-4">
+        {otherFirstNames.map((name) => (
+          <div
+            key={name}
+            className="inline-flex items-center justify-center rounded-sm border-blue-100 bg-blue-100 px-2 py-1 align-middle text-gray-900"
+          >
+            <span>{name}</span>
+            <button
+              aria-label={t('protected:personal-information.name-added-aria-label', { name })}
+              onClick={() => removeOtherFirstName(name)}
+              type="button"
+            >
+              <FontAwesomeIcon icon={faXmark} className="ml-1" />
+            </button>
+
+            <input type="hidden" name="firstNamePreviouslyUsed" value={name} />
+          </div>
+        ))}
+      </div>
+
+      <InputField
+        id="last-name-at-birth-id"
+        defaultValue={defaultFormValues?.lastNameAtBirth ?? primaryDocValues?.lastName}
+        errorMessage={t(getSingleKey(errors?.lastNameAtBirth), { maximum: 100 })}
+        label={t('protected:personal-information.last-name-at-birth.label')}
+        name="lastNameAtBirth"
+        required={true}
+      />
+
+      <div id="other-last-name-input" className="flex space-x-4">
+        <InputField
+          id="last-name-id"
+          className="w-full"
+          errorMessage={t(lastNameError ?? getErrorMessage('lastNamePreviouslyUsed', errors), { maximum: 100 })}
+          helpMessagePrimary={t('protected:personal-information.last-name-previously-used.help-message-primary')}
+          label={t('protected:personal-information.last-name-previously-used.label')}
+          name="lastNamePreviouslyUsed"
+          onChange={({ target }) => setOtherLastName(target.value)}
+          value={otherLastName}
+        />
+        <Button
+          id="add-last-name-button"
+          className="self-end"
+          endIcon={faXmarkCircle}
+          onClick={addOtherLastName}
+          type="button"
+          variant="link"
+        >
+          {t('protected:personal-information.add-name')}
+        </Button>
+      </div>
+
+      <div id="other-last-names" className="flex space-x-4">
+        {otherLastNames.map((name) => (
+          <div
+            key={name}
+            className="inline-flex items-center justify-center rounded-sm border-blue-100 bg-blue-100 px-2 py-1 align-middle text-gray-900"
+          >
+            <span>{name}</span>
+            <button
+              aria-label={t('protected:personal-information.name-added-aria-label', { name })}
+              onClick={() => removeOtherLastName(name)}
+              type="button"
+            >
+              <FontAwesomeIcon icon={faXmark} className="ml-1" />
+            </button>
+
+            <input type="hidden" name="lastNamePreviouslyUsed" value={name} />
+          </div>
+        ))}
+      </div>
+
+      <span aria-live="polite" aria-atomic="true" className="sr-only">
+        {srAnnouncement}
+      </span>
+
+      <InputRadios
+        id="gender-id"
+        errorMessage={t(getSingleKey(errors?.gender))}
+        helpMessagePrimary={t('protected:personal-information.gender.help-message-primary')}
+        legend={t('protected:personal-information.gender.label')}
+        name="gender"
+        options={genderOptions}
+        required={true}
+      />
+    </div>
+  );
+}

--- a/frontend/app/routes/protected/sin-application/previous-sin-form.tsx
+++ b/frontend/app/routes/protected/sin-application/previous-sin-form.tsx
@@ -1,0 +1,59 @@
+import type { ChangeEvent } from 'react';
+import { useState } from 'react';
+
+import type { RouteHandle } from 'react-router';
+
+import { useTranslation } from 'react-i18next';
+
+import { InputPatternField } from '~/components/input-pattern-field';
+import { InputRadios } from '~/components/input-radios';
+import type { Errors, LocalizedOptions, PreviousSinData } from '~/routes/protected/sin-application/types';
+import { getSingleKey } from '~/utils/i18n-utils';
+import { sinInputPatternFormat } from '~/utils/sin-utils';
+
+export const handle = {
+  i18nNamespace: ['protected'],
+} as const satisfies RouteHandle;
+
+interface PreviousSinFormProps {
+  defaultFormValues: PreviousSinData | undefined;
+  localizedApplicantHadSinOptions: LocalizedOptions;
+  errors: Errors;
+}
+
+export default function PreviousSinForm({ defaultFormValues, localizedApplicantHadSinOptions, errors }: PreviousSinFormProps) {
+  const { t } = useTranslation(handle.i18nNamespace);
+
+  const [hasPreviousSin, setHasPreviousSin] = useState(defaultFormValues?.hasPreviousSin);
+
+  const hasPreviousSinOptions = localizedApplicantHadSinOptions.map(({ id, name }) => ({
+    value: id,
+    children: name,
+    defaultChecked: id === defaultFormValues?.hasPreviousSin,
+    onChange: ({ target }: ChangeEvent<HTMLInputElement>) => setHasPreviousSin(target.value),
+  }));
+
+  return (
+    <div className="space-y-6">
+      <InputRadios
+        id="has-previous-sin"
+        legend={t('protected:previous-sin.has-previous-sin-label')}
+        name="hasPreviousSin"
+        options={hasPreviousSinOptions}
+        required
+        errorMessage={t(getSingleKey(errors?.hasPreviousSin))}
+      />
+      {hasPreviousSin === globalThis.__appEnvironment.PP_HAS_HAD_PREVIOUS_SIN_CODE && (
+        <InputPatternField
+          defaultValue={defaultFormValues?.socialInsuranceNumber ?? ''}
+          inputMode="numeric"
+          format={sinInputPatternFormat}
+          id="social-insurance-number"
+          name="socialInsuranceNumber"
+          label={t('protected:previous-sin.social-insurance-number-label')}
+          errorMessage={t(getSingleKey(errors?.socialInsuranceNumber))}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/app/routes/protected/sin-application/primary-docs-form.tsx
+++ b/frontend/app/routes/protected/sin-application/primary-docs-form.tsx
@@ -1,0 +1,272 @@
+import type { JSX } from 'react';
+import { useState } from 'react';
+
+import type { RouteHandle } from 'react-router';
+
+import { useTranslation } from 'react-i18next';
+
+import { DatePickerField } from '~/components/date-picker-field';
+import { InputField } from '~/components/input-field';
+import { InputFile } from '~/components/input-file';
+import { InputRadios } from '~/components/input-radios';
+import { InputSelect } from '~/components/input-select';
+import { APPLICANT_STATUS_IN_CANADA } from '~/domain/constants';
+import type { Errors, LocalizedOptions, PrimaryDocumentData } from '~/routes/protected/sin-application/types';
+import { getSingleKey } from '~/utils/i18n-utils';
+
+export const handle = {
+  i18nNamespace: ['protected'],
+} as const satisfies RouteHandle;
+
+interface PrimaryDocsFormProps {
+  defaultFormValues: PrimaryDocumentData | undefined;
+  localizedStatusInCanada: LocalizedOptions;
+  localizedGenders: LocalizedOptions;
+  errors: Errors;
+}
+
+export default function PrimaryDocsForm({
+  defaultFormValues,
+  localizedStatusInCanada,
+  localizedGenders,
+  errors,
+}: PrimaryDocsFormProps) {
+  const { t } = useTranslation(handle.i18nNamespace);
+
+  const [currentStatus, setCurrentStatus] = useState(defaultFormValues?.currentStatusInCanada);
+  const [documentType, setDocumentType] = useState(defaultFormValues?.documentType);
+
+  return (
+    <div className="space-y-6">
+      <CurrentStatusInCanada
+        defaultValue={defaultFormValues?.currentStatusInCanada}
+        errorMessage={t(getSingleKey(errors?.currentStatusInCanada))}
+        onChange={({ target }) => setCurrentStatus(target.value)}
+        statusInCanada={localizedStatusInCanada}
+      />
+      {currentStatus && (
+        <DocumentType
+          status={currentStatus}
+          value={defaultFormValues?.documentType}
+          error={t(getSingleKey(errors?.documentType))}
+          onChange={({ target }) => setDocumentType(target.value)}
+        />
+      )}
+      {currentStatus && documentType && (
+        <PrimaryDocsFields
+          genders={localizedGenders}
+          status={currentStatus}
+          formValues={defaultFormValues}
+          documentType={documentType}
+          formErrors={errors}
+        />
+      )}
+    </div>
+  );
+}
+
+interface CurrentStatusInCanadaProps {
+  defaultValue?: string;
+  errorMessage?: string;
+  onChange?: React.ChangeEventHandler<HTMLSelectElement>;
+  statusInCanada: LocalizedOptions;
+}
+
+function CurrentStatusInCanada({ defaultValue, errorMessage, onChange, statusInCanada }: CurrentStatusInCanadaProps) {
+  const { t } = useTranslation(handle.i18nNamespace);
+
+  const currentStatusInCanadaOptions = [{ id: 'select-option', name: '' }, ...statusInCanada].map(({ id, name }) => ({
+    value: id === 'select-option' ? '' : id,
+    children: id === 'select-option' ? t('protected:request-details.select-option') : name,
+    disabled: id !== APPLICANT_STATUS_IN_CANADA.canadianCitizenBornOutsideCanada,
+  }));
+
+  return (
+    <>
+      <InputSelect
+        id="currentStatusInCanada"
+        name="currentStatusInCanada"
+        errorMessage={errorMessage}
+        defaultValue={defaultValue ?? ''}
+        required
+        options={currentStatusInCanadaOptions}
+        label={t('protected:primary-identity-document.current-status-in-canada.title')}
+        onChange={onChange}
+      />
+    </>
+  );
+}
+
+type DocumentTypeProps = {
+  error?: string;
+  status?: string;
+  value?: string;
+  onChange?: React.ChangeEventHandler<HTMLSelectElement>;
+};
+
+function DocumentType({ error, status, value, onChange }: DocumentTypeProps) {
+  const { t } = useTranslation(handle.i18nNamespace);
+
+  const canadianCitizenBornOutsideCanadaDocumentType = [
+    'certificate-of-canadian-citizenship',
+    'certificate-of-registration-of-birth-abroad',
+  ] as const;
+
+  const registeredIndianBornInCanadaDocumentType = [
+    'birth-certificate-and-certificate-of-indian-status',
+    'certificate-of-canadian-citizenship-and-certificate-of-indian-status',
+  ] as const;
+
+  const documentTypeOptions = [
+    {
+      children: t('protected:request-details.select-option'),
+      value: '',
+      hidden: true,
+    },
+    ...(() => {
+      switch (status) {
+        case APPLICANT_STATUS_IN_CANADA.canadianCitizenBornOutsideCanada:
+          return canadianCitizenBornOutsideCanadaDocumentType.map((value) => ({
+            value: value,
+            children: t(`protected:primary-identity-document.document-type.options.${value}` as const),
+            disabled: value !== 'certificate-of-canadian-citizenship',
+          }));
+
+        case APPLICANT_STATUS_IN_CANADA.registeredIndianBornInCanada:
+          return registeredIndianBornInCanadaDocumentType.map((value) => ({
+            value: value,
+            children: t(`protected:primary-identity-document.document-type.options.${value}` as const),
+          }));
+
+        default:
+          return [];
+      }
+    })(),
+  ];
+
+  return (
+    <>
+      {(status === APPLICANT_STATUS_IN_CANADA.canadianCitizenBornOutsideCanada ||
+        status === APPLICANT_STATUS_IN_CANADA.registeredIndianBornInCanada) && (
+        <InputSelect
+          id="documentType"
+          name="documentType"
+          errorMessage={error}
+          defaultValue={value}
+          required
+          options={documentTypeOptions}
+          label={t('protected:primary-identity-document.document-type.title')}
+          onChange={onChange}
+        />
+      )}
+    </>
+  );
+}
+
+type PrimaryDocsFieldsProps = {
+  documentType?: string;
+  formErrors?: Record<string, [string, ...string[]] | undefined>;
+  formValues?: Record<string, string | undefined>;
+  genders: LocalizedOptions;
+  status?: string;
+};
+
+function PrimaryDocsFields({ documentType, formErrors, formValues, genders, status }: PrimaryDocsFieldsProps): JSX.Element {
+  const { t } = useTranslation(handle.i18nNamespace);
+
+  const genderOptions = genders.map(({ id, name }) => ({
+    value: id,
+    children: name,
+    defaultChecked: id === formValues?.gender,
+  }));
+
+  return (
+    <>
+      {status === APPLICANT_STATUS_IN_CANADA.canadianCitizenBornOutsideCanada &&
+        documentType === 'certificate-of-canadian-citizenship' && (
+          <>
+            <InputField
+              id="registration-number-id"
+              defaultValue={formValues?.registrationNumber}
+              errorMessage={t(getSingleKey(formErrors?.registrationNumber), { length: 8 })}
+              label={t('protected:primary-identity-document.registration-number.label')}
+              name="registrationNumber"
+              required
+              type="text"
+            />
+            <InputField
+              id="client-number-id"
+              defaultValue={formValues?.clientNumber}
+              errorMessage={t(getSingleKey(formErrors?.clientNumber), { length: 10 })}
+              label={t('protected:primary-identity-document.client-number.label')}
+              name="clientNumber"
+              required
+              type="text"
+            />
+            <InputField
+              id="given-name-id"
+              defaultValue={formValues?.givenName}
+              errorMessage={t(getSingleKey(formErrors?.givenName), { maximum: 100 })}
+              helpMessagePrimary={t('protected:primary-identity-document.given-name.help-message-primary')}
+              label={t('protected:primary-identity-document.given-name.label')}
+              name="givenName"
+              required
+              type="text"
+            />
+            <InputField
+              id="last-name-id"
+              defaultValue={formValues?.lastName}
+              errorMessage={t(getSingleKey(formErrors?.lastName), { maximum: 100 })}
+              helpMessagePrimary={t('protected:primary-identity-document.last-name.help-message-primary')}
+              label={t('protected:primary-identity-document.last-name.label')}
+              name="lastName"
+              required
+              type="text"
+            />
+            <DatePickerField
+              defaultValue={formValues?.dateOfBirth ?? ''}
+              id="date-of-birth-id"
+              legend={t('protected:primary-identity-document.date-of-birth.label')}
+              required
+              names={{ day: 'dateOfBirthDay', month: 'dateOfBirthMonth', year: 'dateOfBirthYear' }}
+              errorMessages={{
+                all: t(getSingleKey(formErrors?.dateOfBirth)),
+                year: t(getSingleKey(formErrors?.dateOfBirthYear)),
+                month: t(getSingleKey(formErrors?.dateOfBirthMonth)),
+                day: t(getSingleKey(formErrors?.dateOfBirthDay)),
+              }}
+            />
+            <InputRadios
+              id="gender-id"
+              errorMessage={t(getSingleKey(formErrors?.gender))}
+              legend={t('protected:primary-identity-document.gender.label')}
+              name="gender"
+              options={genderOptions}
+              required
+            />
+            <DatePickerField
+              defaultValue={formValues?.citizenshipDate ?? ''}
+              id="citizenship-date-id"
+              legend={t('protected:primary-identity-document.citizenship-date.label')}
+              required
+              names={{ day: 'citizenshipDateDay', month: 'citizenshipDateMonth', year: 'citizenshipDateYear' }}
+              errorMessages={{
+                all: t(getSingleKey(formErrors?.citizenshipDate)),
+                year: t(getSingleKey(formErrors?.citizenshipDateYear)),
+                month: t(getSingleKey(formErrors?.citizenshipDateMonth)),
+                day: t(getSingleKey(formErrors?.citizenshipDateDay)),
+              }}
+            />
+            <InputFile
+              disabled
+              accept=".jpg,.png,.heic"
+              id="primary-document-id"
+              name="document"
+              label={t('protected:primary-identity-document.upload-document.label')}
+              required
+            />
+          </>
+        )}
+    </>
+  );
+}

--- a/frontend/app/routes/protected/sin-application/privacy-statement-form.tsx
+++ b/frontend/app/routes/protected/sin-application/privacy-statement-form.tsx
@@ -1,0 +1,39 @@
+import type { RouteHandle } from 'react-router';
+
+import { useTranslation } from 'react-i18next';
+
+import { InputCheckbox } from '~/components/input-checkbox';
+import type { Errors } from '~/routes/protected/sin-application/types';
+import { getSingleKey } from '~/utils/i18n-utils';
+
+export const handle = {
+  i18nNamespace: ['protected'],
+} as const satisfies RouteHandle;
+
+interface PrivacyStatementFormProps {
+  errors: Errors;
+}
+
+export default function PrivacyStatementForm({ errors }: PrivacyStatementFormProps) {
+  const { t } = useTranslation(handle.i18nNamespace);
+
+  return (
+    <div className="max-w-prose space-y-6">
+      <p>{t('protected:privacy-statement.ask-client')}</p>
+      <h2 className="font-lato text-2xl font-bold">{t('protected:privacy-statement.privacy-statement')}</h2>
+      <p>{t('protected:privacy-statement.personal-info')}</p>
+      <p>{t('protected:privacy-statement.participation')}</p>
+      <p>{t('protected:privacy-statement.info-and-docs')}</p>
+      <p>{t('protected:privacy-statement.your-rights')}</p>
+      <InputCheckbox
+        id="agreed-to-terms"
+        name="agreedToTerms"
+        className="h-8 w-8"
+        errorMessage={t(getSingleKey(errors?.agreedToTerms))}
+        required
+      >
+        {t('protected:privacy-statement.confirm-privacy-notice-checkbox.title')}
+      </InputCheckbox>
+    </div>
+  );
+}

--- a/frontend/app/routes/protected/sin-application/request-details-form.tsx
+++ b/frontend/app/routes/protected/sin-application/request-details-form.tsx
@@ -1,0 +1,61 @@
+import type { RouteHandle } from 'react-router';
+
+import { useTranslation } from 'react-i18next';
+
+import { InputRadios } from '~/components/input-radios';
+import { InputSelect } from '~/components/input-select';
+import type { Errors, LocalizedOptions, RequestDetailsData } from '~/routes/protected/sin-application/types';
+import { getSingleKey } from '~/utils/i18n-utils';
+
+export const handle = {
+  i18nNamespace: ['protected'],
+} as const satisfies RouteHandle;
+
+interface RequestDetailsFormProps {
+  defaultFormValues: RequestDetailsData | undefined;
+  localizedSubmissionScenarios: LocalizedOptions;
+  localizedTypeofApplicationToSubmit: LocalizedOptions;
+  errors: Errors;
+}
+
+export default function RequestDetailsForm({
+  defaultFormValues,
+  localizedSubmissionScenarios,
+  localizedTypeofApplicationToSubmit,
+  errors,
+}: RequestDetailsFormProps) {
+  const { t } = useTranslation(handle.i18nNamespace);
+
+  const scenarioOptions = localizedSubmissionScenarios.map(({ id, name }) => ({
+    value: id,
+    children: name,
+    defaultChecked: id === defaultFormValues?.scenario,
+  }));
+
+  const requestOptions = [{ id: 'select-option', name: '' }, ...localizedTypeofApplicationToSubmit].map(({ id, name }) => ({
+    value: id === 'select-option' ? '' : id,
+    children: id === 'select-option' ? t('protected:contact-information.select-option') : name,
+  }));
+
+  return (
+    <div className="space-y-6">
+      <InputRadios
+        id="scenario"
+        legend={t('protected:request-details.select-scenario')}
+        name="scenario"
+        options={scenarioOptions}
+        required
+        errorMessage={t(getSingleKey(errors?.scenario))}
+      />
+      <InputSelect
+        className="w-max rounded-sm"
+        id="request-type"
+        name="request-type"
+        label={t('protected:request-details.type-request')}
+        defaultValue={defaultFormValues?.type ?? ''}
+        options={requestOptions}
+        errorMessage={t(getSingleKey(errors?.type))}
+      />
+    </div>
+  );
+}

--- a/frontend/app/routes/protected/sin-application/secondary-doc-form.tsx
+++ b/frontend/app/routes/protected/sin-application/secondary-doc-form.tsx
@@ -1,0 +1,69 @@
+import type { RouteHandle } from 'react-router';
+
+import { useTranslation } from 'react-i18next';
+
+import { DatePickerField } from '~/components/date-picker-field';
+import { InputFile } from '~/components/input-file';
+import { InputRadios } from '~/components/input-radios';
+import type { Errors, LocalizedOptions, SecondaryDocumentData } from '~/routes/protected/sin-application/types';
+import { getSingleKey } from '~/utils/i18n-utils';
+
+export const handle = {
+  i18nNamespace: ['protected'],
+} as const satisfies RouteHandle;
+
+interface SecondaryDocFormProps {
+  defaultFormValues: SecondaryDocumentData | undefined;
+  localizedApplicantSecondaryDocumentChoices: LocalizedOptions;
+  errors: Errors;
+}
+
+export default function SecondaryDocForm({
+  defaultFormValues,
+  localizedApplicantSecondaryDocumentChoices,
+  errors,
+}: SecondaryDocFormProps) {
+  const { t } = useTranslation(handle.i18nNamespace);
+
+  const docOptions = localizedApplicantSecondaryDocumentChoices.map(({ id, name }) => ({
+    value: id,
+    children: name,
+    defaultChecked: id === defaultFormValues?.documentType,
+  }));
+
+  return (
+    <div className="space-y-10">
+      <InputRadios
+        id="document-type-id"
+        legend={t('protected:secondary-identity-document.document-type.title')}
+        name="document-type"
+        options={docOptions}
+        required
+        errorMessage={t(getSingleKey(errors?.documentType))}
+      />
+      <DatePickerField
+        defaultMonth={Number(defaultFormValues?.expiryMonth)}
+        defaultYear={Number(defaultFormValues?.expiryYear)}
+        id="expiry-date-id"
+        legend={t('protected:secondary-identity-document.expiry-date.title')}
+        required
+        names={{
+          month: 'expiry-month',
+          year: 'expiry-year',
+        }}
+        errorMessages={{
+          year: t(getSingleKey(errors?.expiryYear)),
+          month: t(getSingleKey(errors?.expiryMonth)),
+        }}
+      />
+      <InputFile
+        disabled
+        accept=".jpg,.png,.heic"
+        id="document-id"
+        name="document"
+        label={t('protected:secondary-identity-document.upload-document.title')}
+        required
+      />
+    </div>
+  );
+}

--- a/frontend/app/routes/protected/sin-application/types.d.ts
+++ b/frontend/app/routes/protected/sin-application/types.d.ts
@@ -1,0 +1,114 @@
+export type BirthDetailsData = {
+  country: string;
+  province?: string;
+  city?: string;
+  fromMultipleBirth: boolean;
+};
+
+export type ContactInformationData = {
+  preferredLanguage: string;
+  primaryPhoneNumber: string;
+  secondaryPhoneNumber?: string;
+  emailAddress?: string;
+  country: string;
+  address: string;
+  postalCode: string;
+  city: string;
+  province: string;
+};
+
+export type CurrentNameData =
+  | { preferredSameAsDocumentName: true }
+  | {
+      preferredSameAsDocumentName: false;
+      firstName: string;
+      middleName?: string;
+      lastName: string;
+      supportingDocuments:
+        | { required: false }
+        | {
+            required: true;
+            documentTypes: string[];
+          };
+    };
+
+export type ParentDetailsData = (
+  | { unavailable: true }
+  | {
+      unavailable: false;
+      givenName: string;
+      lastName: string;
+      birthLocation: {
+        country: string;
+        province?: string;
+        city?: string;
+      };
+    }
+)[];
+
+export type PersonalInfoData = {
+  firstNamePreviouslyUsed?: string[];
+  lastNameAtBirth: string;
+  lastNamePreviouslyUsed?: string[];
+  gender: string;
+};
+
+export type PreviousSinData = {
+  hasPreviousSin: string;
+  socialInsuranceNumber?: string;
+};
+
+export type PrimaryDocumentData = {
+  citizenshipDate: string;
+  clientNumber: string;
+  currentStatusInCanada: string;
+  dateOfBirth: string;
+  documentType: string;
+  gender: string;
+  givenName: string;
+  lastName: string;
+  registrationNumber: string;
+};
+
+export type PrivacyStatementData = {
+  agreedToTerms: true;
+};
+
+export type RequestDetailsData = {
+  type: string;
+  scenario: string;
+};
+
+export type SecondaryDocumentData = {
+  documentType: string;
+  expiryMonth: number;
+  expiryYear: number;
+};
+
+export type InPersonSinApplication = {
+  birthDetails: BirthDetailsData;
+  contactInformation: ContactInformationData;
+  currentNameInfo: CurrentNameData;
+  parentDetails: ParentDetailsData;
+  personalInformation: PersonalInfoData;
+  previousSin: PreviousSinData;
+  primaryDocuments: PrimaryDocumentData;
+  privacyStatement: PrivacyStatementData;
+  requestDetails: RequestDetailsData;
+  secondaryDocument: SecondaryDocumentData;
+};
+
+export type Errors = Readonly<Record<string, [string, ...string[]] | undefined>> | undefined;
+
+export type LocalizedLocations = readonly Readonly<{
+  id: string;
+  alphaCode: string;
+  name: string;
+}>[];
+
+export type LocalizedOptions = readonly Readonly<{
+  id: string;
+  name: string;
+}>[];
+
+export {};


### PR DESCRIPTION
## Summary
[AB#18736](https://dev.azure.com/ESDCCM/FSIR/_workitems/edit/18962) Summary and Send for validation screen
[AB#19354](https://dev.azure.com/ESDCCM/FSIR/_workitems/edit/19354) Copy screens to the multichannel flow

### Notable Changes
Added new folder  `routes/protected/sin-application`
- Moved form elements from `protected/person-case/{screen}.tsx` to their own components `protected/sin-application/{screen}Form.tsx`
- Moved types relating to the in-person application from `protected/person-case/types.d.ts` to `protected/sin-application/types.d.ts`
- Moved `validation.server.ts` from `protected/person-case/validation.server.ts` to `protected/sin-application/validation.server.ts`

Updated  `validation.server.ts`
- Moved `formData.get('input')` from **person-case** screens to separate functions to `parseScreenName()`
- Moved In-person application formatting from `person-case/review.tsx` & `multi-channel/send-validation.tsx` to `formatSinApplication()`

Added `multi-channel/edit-application.tsx`
- When editing from `multi-channel/send-validation.tsx`, you are redirected to `edit-application.tsx` with a parameter to determine which form to render

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

### Context
The **Summary and Send for Validation** screen needs to be able to edit the sin application, however the screen cannot use the existing **person-case** screens as they are tied to the in-person flow.

### Objective
The goal of this PR is to refactor **person-case** screens to be able to use their forms to edit the case in the multi-channel flow.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
