### PR TITLE
split out validation status messages into components on /pid-verfication

### DIFF
--- a/frontend/app/.server/locales/protected-en.json
+++ b/frontend/app/.server/locales/protected-en.json
@@ -369,7 +369,11 @@
     "page-title": "Validation result",
     "status-passed": "Passed",
     "validation-passed": "Validation passed",
-    "all-input-successful": "All inputs have been successfully validated and match the primary identity document.",
+    "input-successful": "All inputs have been successfully validated and match the primary identity document.",
+    "status-failed": "Failed",
+    "validation-failed": "Validation failed",
+    "input-failure": "Please check the primary identity document inputs to ensure they match and try again.",
+    "edit": "Edit primary identity document",
     "next": "Next",
     "previous": "Previous",
     "matches": "Matches"

--- a/frontend/app/.server/locales/protected-fr.json
+++ b/frontend/app/.server/locales/protected-fr.json
@@ -370,7 +370,11 @@
     "page-title": "Validation result",
     "status-passed": "Passed",
     "validation-passed": "Validation passed",
-    "all-input-successful": "All inputs have been successfully validated and match the primary identity document.",
+    "input-successful": "All inputs have been successfully validated and match the primary identity document.",
+    "status-failed": "Failed",
+    "validation-failed": "Validation failed",
+    "input-failure": "Please check the primary identity document inputs to ensure they match and try again.",
+    "edit": "Edit primary identity document",
     "next": "Next",
     "previous": "Previous",
     "matches": "Matches"

--- a/frontend/app/routes/protected/multi-channel/pid-verification.tsx
+++ b/frontend/app/routes/protected/multi-channel/pid-verification.tsx
@@ -3,7 +3,7 @@ import { useId } from 'react';
 import type { RouteHandle } from 'react-router';
 import { useFetcher } from 'react-router';
 
-import { faCheck } from '@fortawesome/free-solid-svg-icons';
+import { faCheck, faXmark } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useTranslation } from 'react-i18next';
 
@@ -13,6 +13,7 @@ import { requireAuth } from '~/.server/utils/auth-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
 import { Button } from '~/components/button';
 import { FetcherErrorSummary } from '~/components/error-summary';
+import { InlineLink } from '~/components/links';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
@@ -30,6 +31,7 @@ export async function loader({ context, request }: Route.LoaderArgs) {
 
   // TODO: fetch the verifiction status and send in order to display correct status message
   return {
+    validationSuccess: true,
     documentTitle: t('protected:pid-verification.page-title'),
   };
 }
@@ -70,20 +72,8 @@ export default function PidVerification({ loaderData, actionData, params }: Rout
       <PageTitle subTitle={t('protected:first-time.title')}>{t('protected:pid-verification.page-title')}</PageTitle>
       <FetcherErrorSummary fetcherKey={fetcherKey}>
         <fetcher.Form method="post" noValidate>
-          {/* TODO: refactor status message as reuseable component(s) and display*/}
-          <div
-            id="status-id"
-            role="status"
-            aria-live="polite"
-            className="flex max-w-fit items-center gap-1 rounded-full bg-green-600 px-2 py-1 text-xs text-white"
-          >
-            <FontAwesomeIcon aria-hidden="true" focusable="false" icon={faCheck} />
-            <span>{t('protected:pid-verification.status-passed')}</span>
-          </div>
-          <h2 className="font-lato mt-2 mb-6 text-2xl font-semibold" aria-describedby="status-id">
-            {t('protected:pid-verification.validation-passed')}
-          </h2>
-          <p>{t('protected:pid-verification.all-input-successful')}</p>
+          {loaderData.validationSuccess && <ValidationSuccess />}
+          {!loaderData.validationSuccess && <ValidationFailure />}
           <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
             <Button name="action" value="next" variant="primary" id="continue-button" disabled={isSubmitting}>
               {t('protected:pid-verification.next')}
@@ -94,6 +84,49 @@ export default function PidVerification({ loaderData, actionData, params }: Rout
           </div>
         </fetcher.Form>
       </FetcherErrorSummary>
+    </>
+  );
+}
+
+function ValidationSuccess() {
+  const { t } = useTranslation(handle.i18nNamespace);
+  return (
+    <>
+      <div
+        id="status-id"
+        role="status"
+        aria-live="polite"
+        className="flex max-w-fit items-center gap-1 rounded-full bg-green-600 px-2 py-1 text-xs text-white"
+      >
+        <FontAwesomeIcon aria-hidden="true" focusable="false" icon={faCheck} />
+        <span>{t('protected:pid-verification.status-passed')}</span>
+      </div>
+      <h2 className="font-lato mt-2 mb-6 text-2xl font-semibold" aria-describedby="status-id">
+        {t('protected:pid-verification.validation-passed')}
+      </h2>
+      <p>{t('protected:pid-verification.input-successful')}</p>
+    </>
+  );
+}
+
+function ValidationFailure() {
+  const { t } = useTranslation(handle.i18nNamespace);
+  return (
+    <>
+      <div
+        id="status-id"
+        role="status"
+        aria-live="polite"
+        className="flex max-w-fit items-center gap-1 rounded-full bg-red-600 px-2 py-1 text-xs text-white"
+      >
+        <FontAwesomeIcon aria-hidden="true" focusable="false" icon={faXmark} />
+        <span>{t('protected:pid-verification.status-failed')}</span>
+      </div>
+      <h2 className="font-lato mt-2 mb-6 text-2xl font-semibold" aria-describedby="status-id">
+        {t('protected:pid-verification.validation-failed')}
+      </h2>
+      <p className="mb-6">{t('protected:pid-verification.input-failure')}</p>
+      <InlineLink file="routes/protected/multi-channel/send-validation.tsx">{t('protected:pid-verification.edit')}</InlineLink>
     </>
   );
 }


### PR DESCRIPTION
## Summary

Breaks out the validation status message on `/multi-channel/pid-verification` into separate components for conditional rendering based on the validation status sent back from the server upon "sending for validation" on the previous page.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
