### PR TITLE
feat(frontend): add AWS Cognito authentication strategy

### DIFF
--- a/frontend/app/.server/auth/auth-strategies.ts
+++ b/frontend/app/.server/auth/auth-strategies.ts
@@ -242,6 +242,15 @@ export abstract class BaseAuthenticationStrategy implements AuthenticationStrate
 }
 
 /**
+ * Authentication strategy for AWS Cognito.
+ */
+export class AwsCognitoAuthenticationStrategy extends BaseAuthenticationStrategy {
+  public constructor(issuerUrl: URL, clientId: string, clientSecret: string) {
+    super('awscognito', issuerUrl, { client_id: clientId }, oauth.ClientSecretPost(clientSecret));
+  }
+}
+
+/**
  * Authentication strategy for Azure AD (Microsoft Entra).
  */
 export class AzureADAuthenticationStrategy extends BaseAuthenticationStrategy {

--- a/frontend/tests/auth/auth-strategies.test.ts
+++ b/frontend/tests/auth/auth-strategies.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
 import {
+  AwsCognitoAuthenticationStrategy,
   AzureADAuthenticationStrategy,
   BaseAuthenticationStrategy,
   LocalAuthenticationStrategy,
@@ -182,6 +183,47 @@ describe('auth-strategies', () => {
           state: 'mock_state',
         });
       });
+    });
+  });
+
+  describe('AwsCognitoAuthenticationStrategy', () => {
+    it('should construct a new AwsCognitoAuthenticationStrategy with the correct constructor parameters', async () => {
+      vi.mocked(oauth.processAuthorizationCodeResponse, { partial: true }).mockResolvedValue({
+        access_token: 'access-token',
+      });
+
+      vi.mocked(oauth.validateAuthResponse).mockReturnThis();
+
+      const authenticationStrategy = new AwsCognitoAuthenticationStrategy(
+        new URL('https://auth.example.com/issuer'),
+        'client-id',
+        'client-secret',
+      );
+
+      await authenticationStrategy.exchangeAuthCode(
+        new URL('https://example.com/callback'),
+        new URLSearchParams(),
+        'nonce',
+        'state',
+        'verifier',
+      );
+
+      expect(authenticationStrategy.name).toEqual('awscognito');
+
+      expect(vi.mocked(oauth.discoveryRequest)).toHaveBeenCalledWith(new URL('https://auth.example.com/issuer'), {
+        [oauth.allowInsecureRequests]: false,
+      });
+
+      expect(vi.mocked(oauth.validateAuthResponse)).toHaveBeenCalledWith(
+        {
+          authorization_endpoint: 'https://auth.example.com/authorize',
+          issuer: 'https://auth.example.com/issuer',
+          jwks_uri: 'https://auth.example.com/jwks',
+        },
+        { client_id: 'client-id' },
+        new URLSearchParams(),
+        'state',
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

This is an incremental PR that will ultimately finish with full integration with AWS Cognito.

This PR adds a new authentication strategy, `AwsCognitoAuthenticationStrategy` to `app/.server/auth/auth-strategies.ts` (currently unused).

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)
