### PR TITLE
add newTabIndicator to link components

### DIFF
--- a/frontend/app/.server/locales/gcweb-en.json
+++ b/frontend/app/.server/locales/gcweb-en.json
@@ -108,5 +108,8 @@
   "input-file": {
     "choose-file": "Choose File",
     "no-file": "No file chosen"
+  },
+  "screen-reader": {
+    "new-tab": "opens in a new tab"
   }
 }

--- a/frontend/app/.server/locales/gcweb-fr.json
+++ b/frontend/app/.server/locales/gcweb-fr.json
@@ -108,5 +108,8 @@
   "input-file": {
     "choose-file": "Choisir un fichier",
     "no-file": "Aucun fichier choisi"
+  },
+  "screen-reader": {
+    "new-tab": "s'ouvre dans un nouvel onglet"
   }
 }

--- a/frontend/app/.server/locales/protected-en.json
+++ b/frontend/app/.server/locales/protected-en.json
@@ -376,7 +376,8 @@
     "origin-of-sin-label": "Origin of SIN",
     "final-check": "Final check",
     "first-time": "You are processing a first-time SIN request.",
-    "before-processing": "Before processing the transaction, ensure that you have followed the SIN Application Review Process (SARP).",
+    "before-processing": "Before processing the transaction, ensure that you have followed the <sarpLink>SIN Application Review Process (SARP)</sarpLink>.",
+    "sarp-link": "https://esdc.prv/en/service-canada/isb/sin/references/sinra/sin_app_review_pro_sarp_406.shtml",
     "warnings": {
       "heading": "Warnings",
       "following-warnings": "Based on the data entered, the system has retrieved the following warning(s):",

--- a/frontend/app/.server/locales/protected-fr.json
+++ b/frontend/app/.server/locales/protected-fr.json
@@ -377,7 +377,8 @@
     "origin-of-sin-label": "Origin of SIN",
     "final-check": "Final check",
     "first-time": "You are processing a first-time SIN request.",
-    "before-processing": "Before processing the transaction, ensure that you have followed the SIN Application Review Process (SARP).",
+    "before-processing": "Before processing the transaction, ensure that you have followed the <sarpLink>SIN Application Review Process (SARP)</sarpLink>.",
+    "sarp-link": "https://esdc.prv/fr/service-canada/isb/sin/references/sinra/sin_app_review_pro_sarp_406.shtml",
     "warnings": {
       "heading": "Warnings",
       "following-warnings": "Based on the data entered, the system has retrieved the following warning(s):",

--- a/frontend/app/routes/protected/multi-channel/finalize-request.tsx
+++ b/frontend/app/routes/protected/multi-channel/finalize-request.tsx
@@ -3,7 +3,7 @@ import { useId } from 'react';
 import type { RouteHandle } from 'react-router';
 import { data, useFetcher } from 'react-router';
 
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import * as v from 'valibot';
 
 import type { Info, Route } from './+types/finalize-request';
@@ -18,6 +18,7 @@ import { ContextualAlert } from '~/components/contextual-alert';
 import { FetcherErrorSummary } from '~/components/error-summary';
 import { InputCheckbox } from '~/components/input-checkbox';
 import { InputSelect } from '~/components/input-select';
+import { InlineLink } from '~/components/links';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
@@ -127,7 +128,16 @@ export default function PidVerification({ loaderData, actionData, params }: Rout
             />
             <h2 className="font-lato text-2xl font-semibold">{t('protected:finalize-request.final-check')}</h2>
             <p>{t('protected:finalize-request.first-time')}</p>
-            <p>{t('protected:finalize-request.before-processing')}</p>
+            <p>
+              <Trans
+                i18nKey="protected:finalize-request.before-processing"
+                components={{
+                  sarpLink: (
+                    <InlineLink to={t('protected:finalize-request.sarp-link')} className="external-link" newTabIndicator />
+                  ),
+                }}
+              />
+            </p>
             <h3 className="font-lato text-lg font-semibold">{t('protected:finalize-request.warnings.heading')}</h3>
             <p>{t('protected:finalize-request.warnings.following-warnings')}</p>
             <ContextualAlert type={'warning'}>


### PR DESCRIPTION
## Summary

Similar to cdcp, this PR adds a `NewTabIndicator` component which is used for app-links that open in a new tab.  It adds screenreader accessible text to those links.  This PR implements the new functionality on `/multi-channel/finalize-request` as I noticed Figma was updated with a link to an external resource in one of the paragraphs.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
