### PR TITLE
refactor(frontend): primary docs controlled inputs

### DIFF
--- a/frontend/app/routes/protected/person-case/primary-docs.tsx
+++ b/frontend/app/routes/protected/person-case/primary-docs.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from 'react';
+import type { ChangeEvent, JSX } from 'react';
 import { useId, useState } from 'react';
 
 import type { RouteHandle } from 'react-router';
@@ -137,7 +137,7 @@ export async function loader({ context, request }: Route.LoaderArgs) {
   };
 }
 
-export default function PrimaryDocs({ actionData, loaderData, params }: Route.ComponentProps) {
+export default function PrimaryDocs({ actionData, loaderData, params }: Route.ComponentProps): JSX.Element {
   const { t } = useTranslation(handle.i18nNamespace);
 
   const fetcherKey = useId();
@@ -147,78 +147,80 @@ export default function PrimaryDocs({ actionData, loaderData, params }: Route.Co
   const formValues = fetcher.data?.formValues ?? loaderData.formValues;
   const formErrors = fetcher.data?.formErrors ?? loaderData.formErrors;
 
-  const [currentStatus, setCurrentStatus] = useState(formValues?.currentStatusInCanada);
-  const [documentType, setDocumentType] = useState(formValues?.documentType);
+  const [currentStatus, setCurrentStatus] = useState<string>(formValues?.currentStatusInCanada ?? '');
+  const [documentType, setDocumentType] = useState<string>(formValues?.documentType ?? '');
 
-  function onCurrenStatusChange(currentStatusName: string): void {
-    setCurrentStatus(currentStatusName);
-    //TODO: remove setting the state for documentType when other options for document type are enabled
-    setDocumentType(
-      loaderData.localizedPrimaryDocumentChoices.find(
-        (c) => c.id === APPLICANT_PRIMARY_DOCUMENT_CHOICE.certificateOfCanadianCitizenship,
-      )?.id,
-    );
+  const statusInCanadaChoices = loaderData.localizedStatusInCanada;
+  const documentTypeChoices = loaderData.localizedPrimaryDocumentChoices.filter(({ applicantStatusInCanadaId }) => {
+    return applicantStatusInCanadaId === currentStatus;
+  });
+
+  function handleOnCurrentStatusInCanadaChanged(event: ChangeEvent<HTMLSelectElement>): void {
+    setCurrentStatus(event.target.value);
+    setDocumentType('');
   }
 
   return (
     <>
       <PageTitle subTitle={t('protected:in-person.title')}>{t('protected:primary-identity-document.page-title')}</PageTitle>
-
-      <FetcherErrorSummary fetcherKey={fetcherKey}>
-        <fetcher.Form method="post" noValidate encType="multipart/form-data">
-          <div className="space-y-6">
-            <CurrentStatusInCanada
-              defaultValue={formValues?.currentStatusInCanada}
-              errorMessage={t(getSingleKey(formErrors?.currentStatusInCanada))}
-              onChange={({ target }) => onCurrenStatusChange(target.value)}
-              statusInCanada={loaderData.localizedStatusInCanada}
-            />
-            {currentStatus && (
-              <DocumentType
-                status={currentStatus}
-                value={formValues?.documentType}
-                error={t(getSingleKey(formErrors?.documentType))}
-                onChange={({ target }) => setDocumentType(target.value)}
-                documentTypeChoices={loaderData.localizedPrimaryDocumentChoices.filter(
-                  (c) => c.applicantStatusInCanadaId === currentStatus,
-                )}
+      <div className="max-w-prose">
+        <FetcherErrorSummary fetcherKey={fetcherKey}>
+          <fetcher.Form method="post" noValidate encType="multipart/form-data">
+            <div className="space-y-6">
+              <CurrentStatusInCanada
+                value={currentStatus}
+                onChange={handleOnCurrentStatusInCanadaChanged}
+                statusInCanadaChoices={statusInCanadaChoices}
+                errorMessage={t(getSingleKey(formErrors?.currentStatusInCanada))}
               />
-            )}
-            {currentStatus && documentType && (
-              <PrimaryDocsFields
-                genders={loaderData.localizedGenders}
-                status={currentStatus}
-                formValues={formValues}
-                documentType={documentType}
-                formErrors={formErrors}
-              />
-            )}
-          </div>
-          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <Button name="action" value="next" variant="primary" id="continue-button" disabled={isSubmitting}>
-              {t('protected:person-case.next')}
-            </Button>
-            <Button name="action" value="back" id="back-button" disabled={isSubmitting}>
-              {t('protected:person-case.previous')}
-            </Button>
-          </div>
-        </fetcher.Form>
-      </FetcherErrorSummary>
+              {currentStatus.length > 0 && (
+                <DocumentType
+                  value={documentType}
+                  onChange={({ target }) => setDocumentType(target.value)}
+                  documentTypeChoices={documentTypeChoices}
+                  error={t(getSingleKey(formErrors?.documentType))}
+                />
+              )}
+              {documentType.length > 0 && (
+                <PrimaryDocsFields
+                  genders={loaderData.localizedGenders}
+                  formValues={formValues}
+                  documentType={documentType}
+                  formErrors={formErrors}
+                />
+              )}
+            </div>
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <Button name="action" value="next" variant="primary" id="continue-button" disabled={isSubmitting}>
+                {t('protected:person-case.next')}
+              </Button>
+              <Button name="action" value="back" id="back-button" disabled={isSubmitting}>
+                {t('protected:person-case.previous')}
+              </Button>
+            </div>
+          </fetcher.Form>
+        </FetcherErrorSummary>
+      </div>
     </>
   );
 }
 
 interface CurrentStatusInCanadaProps {
-  defaultValue?: string;
   errorMessage?: string;
-  onChange?: React.ChangeEventHandler<HTMLSelectElement>;
-  statusInCanada: LocalizedApplicantStatusInCanadaChoice[];
+  onChange: React.ChangeEventHandler<HTMLSelectElement>;
+  statusInCanadaChoices: LocalizedApplicantStatusInCanadaChoice[];
+  value: string;
 }
 
-function CurrentStatusInCanada({ defaultValue, errorMessage, onChange, statusInCanada }: CurrentStatusInCanadaProps) {
+function CurrentStatusInCanada({
+  errorMessage,
+  onChange,
+  statusInCanadaChoices,
+  value,
+}: CurrentStatusInCanadaProps): JSX.Element {
   const { t } = useTranslation(handle.i18nNamespace);
 
-  const currentStatusInCanadaOptions = [{ id: 'select-option', name: '' }, ...statusInCanada].map(({ id, name }) => ({
+  const currentStatusInCanadaOptions = [{ id: 'select-option', name: '' }, ...statusInCanadaChoices].map(({ id, name }) => ({
     value: id === 'select-option' ? '' : id,
     children: id === 'select-option' ? t('protected:person-case.select-option') : name,
     disabled: id !== APPLICANT_STATUS_IN_CANADA.canadianCitizenBornOutsideCanada,
@@ -230,11 +232,12 @@ function CurrentStatusInCanada({ defaultValue, errorMessage, onChange, statusInC
         id="currentStatusInCanada"
         name="currentStatusInCanada"
         errorMessage={errorMessage}
-        defaultValue={defaultValue ?? ''}
         required
         options={currentStatusInCanadaOptions}
         label={t('protected:primary-identity-document.current-status-in-canada.title')}
+        value={value}
         onChange={onChange}
+        className="w-full"
       />
     </>
   );
@@ -243,12 +246,11 @@ function CurrentStatusInCanada({ defaultValue, errorMessage, onChange, statusInC
 type DocumentTypeProps = {
   error?: string;
   documentTypeChoices: LocalizedApplicantPrimaryDocumentChoice[];
-  status?: string;
-  value?: string;
-  onChange?: React.ChangeEventHandler<HTMLSelectElement>;
+  value: string;
+  onChange: React.ChangeEventHandler<HTMLSelectElement>;
 };
 
-function DocumentType({ error, documentTypeChoices, status, value, onChange }: DocumentTypeProps) {
+function DocumentType({ error, documentTypeChoices, value, onChange }: DocumentTypeProps): JSX.Element {
   const { t } = useTranslation(handle.i18nNamespace);
 
   const documentTypeOptions = [{ id: 'select-option', name: '' }, ...documentTypeChoices].map(({ id, name }) => ({
@@ -257,33 +259,28 @@ function DocumentType({ error, documentTypeChoices, status, value, onChange }: D
     disabled: id !== APPLICANT_PRIMARY_DOCUMENT_CHOICE.certificateOfCanadianCitizenship,
   }));
   return (
-    <>
-      {(status === APPLICANT_STATUS_IN_CANADA.canadianCitizenBornOutsideCanada ||
-        status === APPLICANT_STATUS_IN_CANADA.registeredIndianBornInCanada) && (
-        <InputSelect
-          id="documentType"
-          name="documentType"
-          errorMessage={error}
-          defaultValue={value}
-          required
-          options={documentTypeOptions}
-          label={t('protected:primary-identity-document.document-type.title')}
-          onChange={onChange}
-        />
-      )}
-    </>
+    <InputSelect
+      id="documentType"
+      name="documentType"
+      errorMessage={error}
+      required
+      options={documentTypeOptions}
+      label={t('protected:primary-identity-document.document-type.title')}
+      value={value}
+      onChange={onChange}
+      className="w-full"
+    />
   );
 }
 
 type PrimaryDocsFieldsProps = {
-  documentType?: string;
+  documentType: string;
   formErrors?: Record<string, [string, ...string[]] | undefined>;
   formValues?: Record<string, string | undefined>;
   genders: LocalizedApplicantGender[];
-  status?: string;
 };
 
-function PrimaryDocsFields({ documentType, formErrors, formValues, genders, status }: PrimaryDocsFieldsProps): JSX.Element {
+function PrimaryDocsFields({ documentType, formErrors, formValues, genders }: PrimaryDocsFieldsProps): JSX.Element {
   const { t } = useTranslation(handle.i18nNamespace);
 
   const genderOptions = genders.map(({ id, name }) => ({
@@ -294,91 +291,92 @@ function PrimaryDocsFields({ documentType, formErrors, formValues, genders, stat
 
   return (
     <>
-      {status === APPLICANT_STATUS_IN_CANADA.canadianCitizenBornOutsideCanada &&
-        documentType === APPLICANT_PRIMARY_DOCUMENT_CHOICE.certificateOfCanadianCitizenship && (
-          <>
-            <InputField
-              id="registration-number-id"
-              defaultValue={formValues?.registrationNumber}
-              errorMessage={t(getSingleKey(formErrors?.registrationNumber), { length: 8 })}
-              label={t('protected:primary-identity-document.registration-number.label')}
-              name="registrationNumber"
-              required
-              type="text"
-            />
-            <InputField
-              id="client-number-id"
-              defaultValue={formValues?.clientNumber}
-              errorMessage={t(getSingleKey(formErrors?.clientNumber), { length: 10 })}
-              label={t('protected:primary-identity-document.client-number.label')}
-              name="clientNumber"
-              required
-              type="text"
-            />
-            <InputField
-              id="given-name-id"
-              defaultValue={formValues?.givenName}
-              errorMessage={t(getSingleKey(formErrors?.givenName), { maximum: 100 })}
-              helpMessagePrimary={t('protected:primary-identity-document.given-name.help-message-primary')}
-              label={t('protected:primary-identity-document.given-name.label')}
-              name="givenName"
-              required
-              type="text"
-            />
-            <InputField
-              id="last-name-id"
-              defaultValue={formValues?.lastName}
-              errorMessage={t(getSingleKey(formErrors?.lastName), { maximum: 100 })}
-              helpMessagePrimary={t('protected:primary-identity-document.last-name.help-message-primary')}
-              label={t('protected:primary-identity-document.last-name.label')}
-              name="lastName"
-              required
-              type="text"
-            />
-            <DatePickerField
-              defaultValue={formValues?.dateOfBirth ?? ''}
-              id="date-of-birth-id"
-              legend={t('protected:primary-identity-document.date-of-birth.label')}
-              required
-              names={{ day: 'dateOfBirthDay', month: 'dateOfBirthMonth', year: 'dateOfBirthYear' }}
-              errorMessages={{
-                all: t(getSingleKey(formErrors?.dateOfBirth)),
-                year: t(getSingleKey(formErrors?.dateOfBirthYear)),
-                month: t(getSingleKey(formErrors?.dateOfBirthMonth)),
-                day: t(getSingleKey(formErrors?.dateOfBirthDay)),
-              }}
-            />
-            <InputRadios
-              id="gender-id"
-              errorMessage={t(getSingleKey(formErrors?.gender))}
-              legend={t('protected:primary-identity-document.gender.label')}
-              name="gender"
-              options={genderOptions}
-              required
-            />
-            <DatePickerField
-              defaultValue={formValues?.citizenshipDate ?? ''}
-              id="citizenship-date-id"
-              legend={t('protected:primary-identity-document.citizenship-date.label')}
-              required
-              names={{ day: 'citizenshipDateDay', month: 'citizenshipDateMonth', year: 'citizenshipDateYear' }}
-              errorMessages={{
-                all: t(getSingleKey(formErrors?.citizenshipDate)),
-                year: t(getSingleKey(formErrors?.citizenshipDateYear)),
-                month: t(getSingleKey(formErrors?.citizenshipDateMonth)),
-                day: t(getSingleKey(formErrors?.citizenshipDateDay)),
-              }}
-            />
-            <InputFile
-              disabled
-              accept=".jpg,.png,.heic"
-              id="primary-document-id"
-              name="document"
-              label={t('protected:primary-identity-document.upload-document.label')}
-              required
-            />
-          </>
-        )}
+      {documentType === APPLICANT_PRIMARY_DOCUMENT_CHOICE.certificateOfCanadianCitizenship && (
+        <>
+          <InputField
+            id="registration-number-id"
+            defaultValue={formValues?.registrationNumber}
+            errorMessage={t(getSingleKey(formErrors?.registrationNumber), { length: 8 })}
+            label={t('protected:primary-identity-document.registration-number.label')}
+            name="registrationNumber"
+            required
+            type="text"
+          />
+          <InputField
+            id="client-number-id"
+            defaultValue={formValues?.clientNumber}
+            errorMessage={t(getSingleKey(formErrors?.clientNumber), { length: 10 })}
+            label={t('protected:primary-identity-document.client-number.label')}
+            name="clientNumber"
+            required
+            type="text"
+          />
+          <InputField
+            id="given-name-id"
+            defaultValue={formValues?.givenName}
+            errorMessage={t(getSingleKey(formErrors?.givenName), { maximum: 100 })}
+            helpMessagePrimary={t('protected:primary-identity-document.given-name.help-message-primary')}
+            label={t('protected:primary-identity-document.given-name.label')}
+            name="givenName"
+            required
+            type="text"
+            className="w-full"
+          />
+          <InputField
+            id="last-name-id"
+            defaultValue={formValues?.lastName}
+            errorMessage={t(getSingleKey(formErrors?.lastName), { maximum: 100 })}
+            helpMessagePrimary={t('protected:primary-identity-document.last-name.help-message-primary')}
+            label={t('protected:primary-identity-document.last-name.label')}
+            name="lastName"
+            required
+            type="text"
+            className="w-full"
+          />
+          <DatePickerField
+            defaultValue={formValues?.dateOfBirth ?? ''}
+            id="date-of-birth-id"
+            legend={t('protected:primary-identity-document.date-of-birth.label')}
+            required
+            names={{ day: 'dateOfBirthDay', month: 'dateOfBirthMonth', year: 'dateOfBirthYear' }}
+            errorMessages={{
+              all: t(getSingleKey(formErrors?.dateOfBirth)),
+              year: t(getSingleKey(formErrors?.dateOfBirthYear)),
+              month: t(getSingleKey(formErrors?.dateOfBirthMonth)),
+              day: t(getSingleKey(formErrors?.dateOfBirthDay)),
+            }}
+          />
+          <InputRadios
+            id="gender-id"
+            errorMessage={t(getSingleKey(formErrors?.gender))}
+            legend={t('protected:primary-identity-document.gender.label')}
+            name="gender"
+            options={genderOptions}
+            required
+          />
+          <DatePickerField
+            defaultValue={formValues?.citizenshipDate ?? ''}
+            id="citizenship-date-id"
+            legend={t('protected:primary-identity-document.citizenship-date.label')}
+            required
+            names={{ day: 'citizenshipDateDay', month: 'citizenshipDateMonth', year: 'citizenshipDateYear' }}
+            errorMessages={{
+              all: t(getSingleKey(formErrors?.citizenshipDate)),
+              year: t(getSingleKey(formErrors?.citizenshipDateYear)),
+              month: t(getSingleKey(formErrors?.citizenshipDateMonth)),
+              day: t(getSingleKey(formErrors?.citizenshipDateDay)),
+            }}
+          />
+          <InputFile
+            disabled
+            accept=".jpg,.png,.heic"
+            id="primary-document-id"
+            name="document"
+            label={t('protected:primary-identity-document.upload-document.label')}
+            required
+          />
+        </>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Summary

Refactor the primary documents to use controlled select inputs for the `Current status in Canada` and `Document type` fields. Additionally, update the form and input styles.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
