### PR TITLE
feat(server): add temporary AWS ID token validation for development

### DIFF
--- a/frontend/app/.server/environment/server.ts
+++ b/frontend/app/.server/environment/server.ts
@@ -44,6 +44,41 @@ export const server = v.pipe(
     ...telemetry.entries,
     NODE_ENV: v.optional(v.picklist(['production', 'development', 'test']), defaults.NODE_ENV),
     PORT: v.optional(v.pipe(stringToIntegerSchema(), v.minValue(0)), defaults.PORT),
+
+    // TTTTTTTTTTTTTTTTTTTTTTT     OOOOOOOOO     DDDDDDDDDDDDD             OOOOOOOOO
+    // T:::::::::::::::::::::T   OO:::::::::OO   D::::::::::::DDD        OO:::::::::OO
+    // T:::::::::::::::::::::T OO:::::::::::::OO D:::::::::::::::DD    OO:::::::::::::OO
+    // T:::::TT:::::::TT:::::TO:::::::OOO:::::::ODDD:::::DDDDD:::::D  O:::::::OOO:::::::O
+    // TTTTTT  T:::::T  TTTTTTO::::::O   O::::::O  D:::::D    D:::::D O::::::O   O::::::O
+    //         T:::::T        O:::::O     O:::::O  D:::::D     D:::::DO:::::O     O:::::O
+    //         T:::::T        O:::::O     O:::::O  D:::::D     D:::::DO:::::O     O:::::O
+    //         T:::::T        O:::::O     O:::::O  D:::::D     D:::::DO:::::O     O:::::O
+    //         T:::::T        O:::::O     O:::::O  D:::::D     D:::::DO:::::O     O:::::O
+    //         T:::::T        O:::::O     O:::::O  D:::::D     D:::::DO:::::O     O:::::O
+    //         T:::::T        O:::::O     O:::::O  D:::::D     D:::::DO:::::O     O:::::O
+    //         T:::::T        O::::::O   O::::::O  D:::::D    D:::::D O::::::O   O::::::O
+    //       TT:::::::TT      O:::::::OOO:::::::ODDD:::::DDDDD:::::D  O:::::::OOO:::::::O
+    //       T:::::::::T       OO:::::::::::::OO D:::::::::::::::DD    OO:::::::::::::OO
+    //       T:::::::::T         OO:::::::::OO   D::::::::::::DDD        OO:::::::::OO
+    //       TTTTTTTTTTT           OOOOOOOOO     DDDDDDDDDDDDD             OOOOOOOOO
+    //
+    // TODO ::: GjB ::: remove after demo
+    TMP_AWS_ID_TOKEN: v.optional(
+      v.string(),
+      // Note that while this might look dangerous, this is only ever used in
+      // devmode, so there is no security risk in exposing this to the public!
+      //
+      // The default token contains the following claims:
+      // {
+      //  "aud": "localhost",
+      //  "iss": "future-sir",
+      //  "sub": "00000000-0000-0000-0000-000000000000",
+      //  "given_name": "Application",
+      //  "family_name": "User",
+      //  "email": "user@example.com"
+      // }
+      'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJmdXR1cmUtc2lyIiwiaWF0Ijo5NDY2ODQ4MDAsImV4cCI6NDEwMjQ0NDgwMCwiYXVkIjoibG9jYWxob3N0Iiwic3ViIjoiMDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwIiwiZ2l2ZW5fbmFtZSI6IkFwcGxpY2F0aW9uIiwiZmFtaWx5X25hbWUiOiJVc2VyIiwiZW1haWwiOiJ1c2VyQGV4YW1wbGUuY29tIn0.bHQFw4LHShBjQgNKJ3hBcHTf6aFN8M9j9ZEvw5rHEKk',
+    ),
   }),
   v.rawCheck(({ dataset }) => {
     if (dataset.typed) {


### PR DESCRIPTION
## Summary

This PR adds a temporary environment variable to hold an AWS identity token. This token will be propagated to a downstream API to assert the identity of the logged in user.

Note that a default token has been provided. This token contains placeholder data and, more importantly, cannot be validated by any downstream APIs. The default token is intended to be used simply as a placeholder when running the application locally.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)
