### PR TITLE
chore(gitops): add temporary AWS ID token configuration for March demo

### DIFF
--- a/gitops/overlays/int/external-secrets.yaml
+++ b/gitops/overlays/int/external-secrets.yaml
@@ -17,7 +17,12 @@ spec:
         OTEL_AUTH_HEADER: 'Api-Token {{ .DT_ACCESS_TOKEN }}'
         REDIS_PASSWORD: '{{ .REDIS_PASSWORD }}'
         SESSION_COOKIE_SECRET: '{{ .SESSION_COOKIE_SECRET  }}'
+        # TODO ::: GjB ::: remove after March demo
+        TMP_AWS_ID_TOKEN: '{{ .AWS_ID_TOKEN }}'
   data:
+    # TODO ::: GjB ::: remove after March demo
+    - secretKey: AWS_ID_TOKEN
+      remoteRef: { key: int, property: AWS_ID_TOKEN }
     - secretKey: AZUREAD_CLIENT_SECRET
       remoteRef: { key: int, property: AZUREAD_CLIENT_SECRET }
     - secretKey: INTEROP_API_KEY


### PR DESCRIPTION
## Summary

Add a new ID token to ESO in int. Value has already been added to the vault.
