### PR TITLE
refactor(frontend): service return undefined instead of throwing error

### DIFF
--- a/frontend/app/.server/domain/multi-channel/case-api-service-default.ts
+++ b/frontend/app/.server/domain/multi-channel/case-api-service-default.ts
@@ -8,12 +8,14 @@ export function getDefaultSinCaseService(): SinCaseService {
   return {
     getSinCases: async (): Promise<SinCaseDto[]> => {
       const response = await fetch(`${serverEnvironment.INTEROP_SIN_REG_API_BASE_URL}/cases`);
+      if (response.status === 404) return [];
       if (!response.ok) throw new AppError(`Cases not found.`, ErrorCodes.SIN_CASE_NOT_FOUND);
       return response.json();
     },
 
-    getSinCaseById: async (id: string): Promise<SinCaseDto> => {
+    getSinCaseById: async (id: string): Promise<SinCaseDto | undefined> => {
       const response = await fetch(`${serverEnvironment.INTEROP_SIN_REG_API_BASE_URL}/cases/${id}`);
+      if (response.status === 404) return undefined;
       if (!response.ok) throw new AppError(`Case with ID '${id}' not found.`, ErrorCodes.SIN_CASE_NOT_FOUND);
       return response.json();
     },

--- a/frontend/app/.server/domain/multi-channel/case-api-service.ts
+++ b/frontend/app/.server/domain/multi-channel/case-api-service.ts
@@ -5,7 +5,7 @@ import { serverEnvironment } from '~/.server/environment';
 
 export type SinCaseService = {
   getSinCases(): Promise<SinCaseDto[]>;
-  getSinCaseById(id: string): Promise<SinCaseDto>;
+  getSinCaseById(id: string): Promise<SinCaseDto | undefined>;
 };
 
 export function getSinCaseService(): SinCaseService {

--- a/frontend/app/routes/protected/multi-channel/send-validation.tsx
+++ b/frontend/app/routes/protected/multi-channel/send-validation.tsx
@@ -26,6 +26,7 @@ import { InlineLink } from '~/components/links';
 import { PageTitle } from '~/components/page-title';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
+import { HttpStatusCodes } from '~/errors/http-status-codes';
 import { getTranslation } from '~/i18n-config.server';
 import { handle as parentHandle } from '~/routes/protected/person-case/layout';
 import { ReviewBirthDetails } from '~/routes/protected/sin-application/review-birth-details';
@@ -67,6 +68,12 @@ export async function loader({ context, request }: Route.LoaderArgs) {
 
   // TODO: the id will likely come from a path param in the URL?
   const personSinCase = await getSinCaseService().getSinCaseById('000000000');
+
+  if (personSinCase === undefined) {
+    throw new Response(JSON.stringify({ status: HttpStatusCodes.NOT_FOUND, message: 'Case not found' }), {
+      status: HttpStatusCodes.NOT_FOUND,
+    });
+  }
 
   const {
     birthDetails,


### PR DESCRIPTION
## Summary

The sin-validation page would throw a 500 when the id was not found.. this goes back to the service module throwing when no data is found instead of returning undefined 
The API calls can return 404 but our service should return undefined instead of throwing error

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
