### PR TITLE
feat(frontend): update submission logic

### DIFF
--- a/frontend/app/.server/domain/sin-application/sin-application-models.ts
+++ b/frontend/app/.server/domain/sin-application/sin-application-models.ts
@@ -6,6 +6,7 @@ export type SubmitSinApplicationRequest = {
   personalInformation: SubmitSinApplicationRequestPersonalInfo;
   previousSin: SubmitSinApplicationRequestPreviousSin;
   primaryDocuments: SubmitSinApplicationRequestPrimaryDocument;
+  privacyStatement: SubmitSinApplicationRequestPrivacyStatement;
   requestDetails: SubmitSinApplicationRequestRequestDetails;
   secondaryDocument: SubmitSinApplicationRequestSecondaryDocument;
 };
@@ -94,6 +95,10 @@ export type SubmitSinApplicationRequestPrimaryDocument = {
   givenName: string;
   lastName: string;
   registrationNumber: string;
+};
+
+export type SubmitSinApplicationRequestPrivacyStatement = {
+  agreedToTerms: true;
 };
 
 export type SubmitSinApplicationRequestRequestDetails = {

--- a/frontend/app/.server/domain/sin-application/sin-application-service-mock.ts
+++ b/frontend/app/.server/domain/sin-application/sin-application-service-mock.ts
@@ -1,10 +1,12 @@
+import { randomUUID } from 'node:crypto';
+
+import { setSinCases } from '~/.server/domain/multi-channel/sin-cases-store';
 import type {
   SubmitSinApplicationRequest,
   SubmitSinApplicationResponse,
 } from '~/.server/domain/sin-application/sin-application-models';
 import type { SinApplicationService } from '~/.server/domain/sin-application/sin-application-service';
 import { LogFactory } from '~/.server/logging';
-import { randomString } from '~/utils/string-utils';
 
 const log = LogFactory.getLogger(import.meta.url);
 
@@ -13,9 +15,13 @@ export function getMockSinApplicationService(): SinApplicationService {
     submitSinApplication(submitSinApplicationRequest: SubmitSinApplicationRequest): Promise<SubmitSinApplicationResponse> {
       log.debug('Submitting SIN application request.');
       log.trace('Submitting SIN application with request:', submitSinApplicationRequest);
-      const mockSubmitSinApplicationResponse: SubmitSinApplicationResponse = {
-        identificationId: randomString(9, '0123456789'),
-      };
+
+      const caseId = randomUUID();
+
+      // TODO ::: GjB ::: maybe remove after demo?
+      void setSinCases({ ...submitSinApplicationRequest, caseId: caseId });
+
+      const mockSubmitSinApplicationResponse = { identificationId: caseId };
       log.debug('SIN application submitted successfully with response: %s', mockSubmitSinApplicationResponse);
       return Promise.resolve(mockSubmitSinApplicationResponse);
     },

--- a/frontend/app/routes/protected/person-case/review.tsx
+++ b/frontend/app/routes/protected/person-case/review.tsx
@@ -73,13 +73,11 @@ export async function action({ context, params, request }: Route.ActionArgs) {
         throw new AppError(`Failed to submit SIN application: ${action}`, ErrorCodes.SUBMIT_SIN_APPLICATION_FAILED);
       }
 
-      const createdCase = { caseId: response.identificationId, ...inPersonSinApplication };
-      context.session.createdCases = {
-        ...(context.session.createdCases ?? {}),
-        [createdCase.caseId]: createdCase,
-      };
+      // TODO ::: GjB ::: remove after demo and handle this in xstate
+      throw i18nRedirect('routes/protected/multi-channel/send-validation.tsx', request, {
+        params: { caseId: response.identificationId },
+      });
 
-      machineActor.send({ type: 'submitReview' });
       break;
     }
 
@@ -317,7 +315,7 @@ function validateMachineContextData(
   machineContext: Partial<InPersonSinApplication>,
   tabId: string,
   request: Request,
-): Required<InPersonSinApplication> {
+): InPersonSinApplication {
   const {
     birthDetails,
     contactInformation,

--- a/frontend/app/routes/protected/person-case/state-machine.server.ts
+++ b/frontend/app/routes/protected/person-case/state-machine.server.ts
@@ -28,6 +28,7 @@ import { getRouteByFile } from '~/utils/route-utils';
 
 export type Machine = typeof machine;
 
+// TODO ::: GjB ::: this type should eventually be refactored to hold: { formData, validatedData, submittedData }
 type MachineContext = Partial<InPersonSinApplication> & Partial<{ formData: FormData }>;
 
 type MachineEvents =
@@ -66,7 +67,8 @@ export type StateName =
   | 'parent-info'
   | 'previous-sin-info'
   | 'contact-info'
-  | 'review';
+  | 'review'
+  | 'success';
 
 const log = LogFactory.getLogger(import.meta.url);
 
@@ -266,12 +268,12 @@ export const machine = setup({
           target: 'contact-info',
         },
         submitReview: {
-          target: 'privacy-statement',
-          actions: assign(({ context, event }) => ({
-            // TODO ::: GjB ::: handle final submission
-          })),
+          target: 'success',
         },
       },
+    },
+    'success': {
+      type: 'final',
     },
   },
 });

--- a/frontend/tests/.server/domain/sin-application/sin-application-mappers.test.ts
+++ b/frontend/tests/.server/domain/sin-application/sin-application-mappers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type {
   ApplicantPrimaryDocumentChoice,
@@ -94,6 +94,9 @@ describe('mapSubmitSinApplicationRequestToSinApplicationRequest', () => {
         lastName: 'LastName',
         dateOfBirth: '2000-01-01',
         gender: 'M',
+      },
+      privacyStatement: {
+        agreedToTerms: true,
       },
       requestDetails: { type: 'RequestType', scenario: 'Scenario' },
       secondaryDocument: { documentType: 'SecDocType', expiryYear: '2025', expiryMonth: '12' },
@@ -439,6 +442,9 @@ describe('mapSubmitSinApplicationRequestToSinApplicationRequest', () => {
         lastName: 'LastName',
         dateOfBirth: '2000-01-01',
         gender: 'M',
+      },
+      privacyStatement: {
+        agreedToTerms: true,
       },
       requestDetails: { type: 'RequestType', scenario: 'Scenario' },
       secondaryDocument: { documentType: 'SecDocType', expiryYear: '2025', expiryMonth: '12' },

--- a/frontend/tests/.server/domain/sin-application/sin-application-service-mock.test.ts
+++ b/frontend/tests/.server/domain/sin-application/sin-application-service-mock.test.ts
@@ -1,13 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { mock } from 'vitest-mock-extended';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MockProxy } from 'vitest-mock-extended';
+import { mock } from 'vitest-mock-extended';
 
-import type {
-  SubmitSinApplicationRequest,
-  SubmitSinApplicationResponse,
-} from '~/.server/domain/sin-application/sin-application-models';
+import type { SubmitSinApplicationRequest } from '~/.server/domain/sin-application/sin-application-models';
 import { getMockSinApplicationService } from '~/.server/domain/sin-application/sin-application-service-mock';
-import { randomString } from '~/utils/string-utils';
 
 vi.mock('~/utils/string-utils');
 
@@ -22,17 +18,8 @@ describe('getMockSinApplicationService', () => {
     });
 
     it('should mock submitting the SIN application and return the mock response data', async () => {
-      const identificationIdMock = '123456789';
-
-      vi.mocked(randomString).mockReturnValueOnce(identificationIdMock);
-
-      const expected: SubmitSinApplicationResponse = { identificationId: identificationIdMock };
-
       const result = await service.submitSinApplication(mockRequest);
-
-      expect(result).toEqual(expected);
-      expect(randomString).toHaveBeenCalledExactlyOnceWith(9, '0123456789');
-      expect(randomString).toHaveReturnedWith(identificationIdMock);
+      expect(result.identificationId).not.toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Summary

Update in-person submission logic to store the data in the mock store and then link to the multi-channel flow. (see attached video)

**Important:** this code will have eventually have to be removed and replaced with proper handling in the state machine.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

## Screenshots

[Screencast from 2025-03-26 08-57-02.webm](https://github.com/user-attachments/assets/8289060d-bdfb-45a5-8895-20316ab9f844)
