### PR TITLE
fix(gitops): reduce refresh interval for external secrets from 1h to 5m

### DIFF
--- a/gitops/overlays/int/external-secrets.yaml
+++ b/gitops/overlays/int/external-secrets.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: future-sir-frontend
 spec:
-  refreshInterval: 1h
+  refreshInterval: 5m
   secretStoreRef:
     name: vault-backend
     kind: SecretStore


### PR DESCRIPTION
## Summary

Reducing the TTL for the ESO secrets down to 5m since we want a quick update after modifying the vault values.
