### PR TITLE
refactor(frontend): redirect to protected dashboard after multi-channel flow completion

### DIFF
--- a/frontend/app/routes/protected/multi-channel/sin-confirmation.tsx
+++ b/frontend/app/routes/protected/multi-channel/sin-confirmation.tsx
@@ -76,7 +76,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
 
   switch (action) {
     case 'finish': {
-      throw i18nRedirect('routes/protected/request.tsx', request); //TODO: update redirect to proper page
+      throw i18nRedirect('routes/protected/index.tsx', request);
     }
     case 'print': {
       // TODO: fetch the proper sin


### PR DESCRIPTION
## Summary

[AB#19772](https://dev.azure.com/ESDCCM/FSIR/_workitems/edit/19772)
Redirect to protected dashboard after multi-channel flow completion.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
