### PR TITLE
fix(frontend): add submitted application to store after API call

### DIFF
--- a/frontend/app/.server/domain/sin-application/sin-application-mappers.ts
+++ b/frontend/app/.server/domain/sin-application/sin-application-mappers.ts
@@ -20,6 +20,7 @@ import type {
   SinApplicationRequest,
   SinApplicationResponse,
 } from '~/.server/shared/api/interop';
+import { AppError } from '~/errors/app-error';
 
 /**
  * Maps the SubmitSinApplicationRequest to SinApplicationRequest (NIEM).
@@ -413,7 +414,12 @@ function createSubmitSinApplicationRequestToSinApplicationRequestMappingHelpers(
 export function mapSinApplicationResponseToSubmitSinApplicationResponse(
   sinApplicationResponse: SinApplicationResponse,
 ): SubmitSinApplicationResponse {
+  if (sinApplicationResponse.SINApplication?.SINApplicationIdentification?.IdentificationID === undefined) {
+    // TODO ::: GjB ::: it's not clear if this potentially undefined value is intentional; the OpenAPI spec allows for it, so we have to check for it
+    throw new AppError('Failed to map SIN application response; IdentificationID is undefined');
+  }
+
   return {
-    identificationId: sinApplicationResponse.SINApplication?.SINApplicationIdentification?.IdentificationID,
+    identificationId: sinApplicationResponse.SINApplication.SINApplicationIdentification.IdentificationID,
   };
 }

--- a/frontend/app/.server/domain/sin-application/sin-application-models.ts
+++ b/frontend/app/.server/domain/sin-application/sin-application-models.ts
@@ -113,5 +113,5 @@ export type SubmitSinApplicationRequestSecondaryDocument = {
 };
 
 export type SubmitSinApplicationResponse = {
-  identificationId: string | undefined;
+  identificationId: string;
 };

--- a/frontend/app/.server/domain/sin-application/sin-application-service-default.ts
+++ b/frontend/app/.server/domain/sin-application/sin-application-service-default.ts
@@ -1,3 +1,4 @@
+import { setSinCases } from '~/.server/domain/multi-channel/sin-cases-store';
 import {
   mapSinApplicationResponseToSubmitSinApplicationResponse,
   mapSubmitSinApplicationRequestToSinApplicationRequest,
@@ -16,9 +17,9 @@ const log = LogFactory.getLogger(import.meta.url);
 
 export function getDefaultSinApplicationService(): SinApplicationService {
   return {
-    async submitSinApplication(
+    submitSinApplication: async (
       submitSinApplicationRequest: SubmitSinApplicationRequest,
-    ): Promise<SubmitSinApplicationResponse> {
+    ): Promise<SubmitSinApplicationResponse> => {
       log.debug('Submitting SIN application request.');
       log.trace('Submitting SIN application with request:', submitSinApplicationRequest);
 
@@ -36,6 +37,10 @@ export function getDefaultSinApplicationService(): SinApplicationService {
       }
 
       const submitSinApplicationResponse = mapSinApplicationResponseToSubmitSinApplicationResponse(data);
+
+      // TODO ::: GjB ::: maybe remove after demo?
+      void setSinCases({ ...submitSinApplicationRequest, caseId: submitSinApplicationResponse.identificationId });
+
       log.debug('SIN application submitted successfully with response: %s', submitSinApplicationResponse);
       return submitSinApplicationResponse;
     },

--- a/frontend/app/routes/protected/person-case/review.tsx
+++ b/frontend/app/routes/protected/person-case/review.tsx
@@ -69,10 +69,6 @@ export async function action({ context, params, request }: Route.ActionArgs) {
       const sinApplicationService = getSinApplicationService();
       const response = await sinApplicationService.submitSinApplication(inPersonSinApplication);
 
-      if (response.identificationId === undefined) {
-        throw new AppError(`Failed to submit SIN application: ${action}`, ErrorCodes.SUBMIT_SIN_APPLICATION_FAILED);
-      }
-
       // TODO ::: GjB ::: remove after demo and handle this in xstate
       throw i18nRedirect('routes/protected/multi-channel/send-validation.tsx', request, {
         params: { caseId: response.identificationId },


### PR DESCRIPTION
([AB#19766](https://dev.azure.com/ESDCCM/a4b4f7af-bbd7-4f0d-83ab-a123d0b70fda/_workitems/edit/19766) -- ensure successfully submitted person-case is stored in sin cases store)

## Summary

This PR adds code to store the a SIN application to the temporary sin-cases-store after successful submit.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)
