### PR TITLE
fix(frontend): fix typos in .env.example

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -221,11 +221,11 @@ PP_APPLICANT_STATUS_IN_CANADA_CANADIAN_CITIZEN_CODE=
 
 # Power Platform Applicant primary document choice code for `Certificate of Canadian Citizenship issued by IRCC or CIC` (default: 564190001)
 # see app/.server/resources/esdc_applicantprimarydocumentchoices.json
-PP_APPLICANT_PRIMARY_DOCUMENT_TYPE_CERTIFICATE_CANADIAN_CITIZENSHIP_CODE
+PP_APPLICANT_PRIMARY_DOCUMENT_TYPE_CERTIFICATE_CANADIAN_CITIZENSHIP_CODE=
 
 # Power Platform SIN confirmation receiving codes for `MAIL` (default: Mail)
 # see other/specs/fsir-openapi.yml line#239
-PP_SIN_CONFIRMATION_RECEIVING_METHOD_CODE
+PP_SIN_CONFIRMATION_RECEIVING_METHOD_CODE=
 
 #################################################
 # Interop API configuration


### PR DESCRIPTION
## Summary

The diff is self-explanatory.
