### PR TITLE
fix(frontend): add session/machine cleanup when submitting

### DIFF
--- a/frontend/app/routes/protected/person-case/review.tsx
+++ b/frontend/app/routes/protected/person-case/review.tsx
@@ -69,6 +69,9 @@ export async function action({ context, params, request }: Route.ActionArgs) {
       const sinApplicationService = getSinApplicationService();
       const response = await sinApplicationService.submitSinApplication(inPersonSinApplication);
 
+      // TODO ::: GjB ::: this is a poor-man's session cleanup; remove once xstate is correctly handling the API call
+      machineActor.send({ type: 'cancel' });
+
       // TODO ::: GjB ::: remove after demo and handle this in xstate
       throw i18nRedirect('routes/protected/multi-channel/send-validation.tsx', request, {
         params: { caseId: response.identificationId },


### PR DESCRIPTION
([AB#19767](https://dev.azure.com/ESDCCM/a4b4f7af-bbd7-4f0d-83ab-a123d0b70fda/_workitems/edit/19767) -- ensure person-case is destroyed after submission)

## Summary

Kill the state machine after a successful API call. This code is not intended to stay in the application for long.. once the API call is moved to the state machine (or we remove the state machine), this code should be removed.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)
