### PR TITLE
refactor(frontend): review country field on parent details screen

### DIFF
--- a/frontend/app/.server/domain/multi-channel/sin-case-models.ts
+++ b/frontend/app/.server/domain/multi-channel/sin-case-models.ts
@@ -53,7 +53,7 @@ export type SinCaseParentDetailsDto =
       givenName: string;
       lastName: string;
       birthLocation: {
-        country: string;
+        country?: string;
         province?: string;
         city?: string;
       };

--- a/frontend/app/.server/domain/sin-application/sin-application-models.ts
+++ b/frontend/app/.server/domain/sin-application/sin-application-models.ts
@@ -66,7 +66,7 @@ export type SubmitSinApplicationRequestParentDetails = (
       givenName: string;
       lastName: string;
       birthLocation: {
-        country: string;
+        country?: string;
         province?: string | undefined;
         city?: string | undefined;
       };

--- a/frontend/app/routes/protected/person-case/parent-details.tsx
+++ b/frontend/app/routes/protected/person-case/parent-details.tsx
@@ -199,7 +199,6 @@ function ParentForm({ index, loaderData, errors, onRemove }: ParentFormProps) {
   const countryOptions = [{ id: 'select-option', name: '' }, ...loaderData.localizedCountries].map(({ id, name }) => ({
     value: id === 'select-option' ? '' : id,
     children: id === 'select-option' ? t('protected:person-case.select-option') : name,
-    disabled: id === 'select-option',
   }));
 
   const provinceOptions = [{ id: 'select-option', name: '' }, ...loaderData.localizedProvincesTerritoriesStates].map(
@@ -261,7 +260,6 @@ function ParentForm({ index, loaderData, errors, onRemove }: ParentFormProps) {
             defaultValue={defaultValues?.birthLocation?.country ?? ''}
             options={countryOptions}
             onChange={({ target }) => setCountry(target.value)}
-            required
           />
           {country === globalThis.__appEnvironment.PP_CANADA_COUNTRY_CODE ? (
             <InputSelect
@@ -270,7 +268,6 @@ function ParentForm({ index, loaderData, errors, onRemove }: ParentFormProps) {
               id={`${index}-province-id`}
               name={`${index}-province`}
               label={t('protected:parent-details.province')}
-              required
               defaultValue={defaultValues?.birthLocation?.province ?? ''}
               options={provinceOptions}
             />
@@ -290,7 +287,6 @@ function ParentForm({ index, loaderData, errors, onRemove }: ParentFormProps) {
             label={t('protected:parent-details.city')}
             name={`${index}-city`}
             defaultValue={defaultValues?.birthLocation?.city ?? ''}
-            required={country === globalThis.__appEnvironment.PP_CANADA_COUNTRY_CODE}
             type="text"
           />
         </>

--- a/frontend/app/routes/protected/person-case/state-machine-models.ts
+++ b/frontend/app/routes/protected/person-case/state-machine-models.ts
@@ -67,7 +67,7 @@ export type ParentDetailsData = (
       givenName: string;
       lastName: string;
       birthLocation: {
-        country: string;
+        country?: string;
         province?: string;
         city?: string;
       };

--- a/frontend/app/routes/protected/person-case/validation.server.ts
+++ b/frontend/app/routes/protected/person-case/validation.server.ts
@@ -235,7 +235,6 @@ export const parentDetailsSchema = v.pipe(
                 city: v.pipe(
                   v.string('protected:parent-details.city-error.required-city'),
                   v.trim(),
-                  v.nonEmpty('protected:parent-details.city-error.required-city'),
                   v.maxLength(100, 'protected:parent-details.city-error.invalid-city'),
                   v.regex(REGEX_PATTERNS.NON_DIGIT, 'protected:parent-details.city-error.invalid-city'),
                 ),
@@ -243,7 +242,6 @@ export const parentDetailsSchema = v.pipe(
               v.object({
                 country: v.pipe(
                   v.string('protected:parent-details.country-error.required-country'),
-                  v.nonEmpty('protected:parent-details.country-error.required-country'),
                   v.excludes(
                     serverEnvironment.PP_CANADA_COUNTRY_CODE,
                     'protected:parent-details.country-error.invalid-country',
@@ -259,7 +257,6 @@ export const parentDetailsSchema = v.pipe(
                   v.pipe(
                     v.string('protected:parent-details.province-error.required-province'),
                     v.trim(),
-                    v.nonEmpty('protected:parent-details.province-error.required-province'),
                     v.maxLength(100, 'protected:parent-details.province-error.invalid-province'),
                     v.regex(REGEX_PATTERNS.NON_DIGIT, 'protected:parent-details.province-error.invalid-province'),
                   ),
@@ -268,11 +265,13 @@ export const parentDetailsSchema = v.pipe(
                   v.pipe(
                     v.string('protected:parent-details.city-error.required-city'),
                     v.trim(),
-                    v.nonEmpty('protected:parent-details.city-error.required-city'),
                     v.maxLength(100, 'protected:parent-details.city-error.invalid-city'),
                     v.regex(REGEX_PATTERNS.NON_DIGIT, 'protected:parent-details.city-error.invalid-city'),
                   ),
                 ),
+              }),
+              v.object({
+                country: v.optional(v.pipe(v.string(), v.trim())),
               }),
             ],
             'protected:parent-details.country-error.required-country',

--- a/frontend/app/routes/protected/sin-application/review-parent-details.tsx
+++ b/frontend/app/routes/protected/sin-application/review-parent-details.tsx
@@ -12,7 +12,7 @@ interface ReviewParentDetailsProps {
     givenName?: string;
     lastName?: string;
     birthLocation?: {
-      country: string;
+      country?: string;
       city?: string;
       province?: string;
     };


### PR DESCRIPTION
## Summary

[AB#19764](https://dev.azure.com/ESDCCM/FSIR/_workitems/edit/19764)
Country field in the Parent/Legal Details route should be optional as per Figma. Updated validation to remove error on Country field. Also updated DTOs and model to indicate Country is optional.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/4252c088-69ee-4d17-a40d-7912c957d7ea)
