### PR TITLE
fix(frontend): tweak `setMaxListeners()` call

### DIFF
--- a/frontend/app/.server/express/server.ts
+++ b/frontend/app/.server/express/server.ts
@@ -11,15 +11,6 @@ import { LogFactory } from '~/.server/logging';
 
 const log = LogFactory.getLogger(import.meta.url);
 
-// accommodate the extra uncaughtException and unhandledRejection listeners
-// added by winston by increasing the max number of listeners by 25%
-// see: https://github.com/winstonjs/winston/blob/v3.17.0/lib/winston/exception-handler.js#L51
-// see: https://github.com/winstonjs/winston/blob/v3.17.0/lib/winston/rejection-handler.js#L51
-const existingMaxListeners = process.getMaxListeners();
-const increasedMaxListeners = Math.round(existingMaxListeners * 1.25);
-log.debug('Setting process.maxListeners to to %s (was: %s)', increasedMaxListeners, existingMaxListeners);
-process.setMaxListeners(increasedMaxListeners);
-
 log.info('Installing source map support');
 sourceMapSupport.install();
 


### PR DESCRIPTION
## Summary

Whenever a new logger is created by winston, it adds two new event listeners (one for  `uncaughtException` and one for `unhandledRejection`).

Nodejs configures `process.maxListeners` to be 10 by default, and then issues the following warning if more than the max are registered:

```
MaxListenersExceededWarning: Possible EventEmitter memory leak detected. XX event listeners added to [process]. MaxListeners is YY. Use emitter.setMaxListeners() to increase limit.
```

This PR simply increments `process.maxListeners` by two every time a new logger is created to accommodate the new listeners added by winston.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)
