### PR TITLE
refactor(frontend): fix province name on sin confirmation screen

### DIFF
--- a/frontend/app/routes/protected/multi-channel/sin-confirmation.tsx
+++ b/frontend/app/routes/protected/multi-channel/sin-confirmation.tsx
@@ -12,6 +12,7 @@ import type { Info, Route } from './+types/sin-confirmation';
 import { getAssociateSinService } from '~/.server/domain/multi-channel/associate-sin-service';
 import { getSinCaseService } from '~/.server/domain/multi-channel/case-api-service';
 import { serverEnvironment } from '~/.server/environment';
+import { getLocalizedProvinceById } from '~/.server/shared/services/province-service';
 import { requireAllRoles } from '~/.server/utils/auth-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
 import { Button } from '~/components/button';
@@ -29,7 +30,7 @@ export const handle = {
 
 export async function loader({ context, params, request }: Route.LoaderArgs) {
   requireAllRoles(context.session, new URL(request.url), ['user']);
-  const { t } = await getTranslation(request, handle.i18nNamespace);
+  const { lang, t } = await getTranslation(request, handle.i18nNamespace);
 
   // TODO ::: GjB ::: the data returned by the following call should be checked to ensure the logged-in user has permissions to view it
   const personSinCase = await getSinCaseService().findSinCaseById(params.caseId);
@@ -53,6 +54,11 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
       address: personSinCase.contactInformation.address,
       city: personSinCase.contactInformation.city,
       province: personSinCase.contactInformation.province,
+      provinceName: personSinCase.contactInformation.province
+        ? personSinCase.contactInformation.country === serverEnvironment.PP_CANADA_COUNTRY_CODE
+          ? getLocalizedProvinceById(personSinCase.contactInformation.province, lang).name
+          : personSinCase.contactInformation.province
+        : undefined,
       postalCode: personSinCase.contactInformation.postalCode,
     },
   };
@@ -176,7 +182,7 @@ export default function SinConfirmation({ loaderData, actionData, params }: Rout
               <span className="block">{recordDetails.address}</span>
               <span className="block">
                 {recordDetails.city && <span className="mr-[0.5ch]">{recordDetails.city}</span>}
-                {recordDetails.province && <span className="mr-[0.5ch]">{recordDetails.province}</span>}
+                {recordDetails.provinceName && <span className="mr-[0.5ch]">{recordDetails.provinceName}</span>}
                 {recordDetails.postalCode}
               </span>
             </ConfirmationDetail>


### PR DESCRIPTION
## Summary

[AB#19552](https://dev.azure.com/ESDCCM/FSIR/_workitems/edit/19552)
Display correct province name on sin confirmation screen instead of guid

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/70ff3ce5-a028-4170-9053-9651127176b9)
