### PR TITLE
refactor(frontend): replace `getSingleKey()` with `extractValidationKey()` for improved readability

### DIFF
--- a/frontend/app/routes/protected/person-case/birth-details.tsx
+++ b/frontend/app/routes/protected/person-case/birth-details.tsx
@@ -26,8 +26,8 @@ import { handle as parentHandle } from '~/routes/protected/person-case/layout';
 import { getTabIdOrRedirect, loadMachineActorOrRedirect } from '~/routes/protected/person-case/route-helpers.server';
 import { getStateRoute } from '~/routes/protected/person-case/state-machine.server';
 import { birthDetailsSchema } from '~/routes/protected/person-case/validation.server';
-import { getSingleKey } from '~/utils/i18n-utils';
 import { trimToUndefined } from '~/utils/string-utils';
+import { extractValidationKey } from '~/utils/validation-utils';
 
 const REQUIRE_OPTIONS = { yes: 'Yes', no: 'No' } as const;
 
@@ -151,7 +151,7 @@ export default function BirthDetails({ actionData, loaderData, matches, params }
               <InputSelect
                 id="country-id"
                 name="country"
-                errorMessage={t(getSingleKey(errors?.country))}
+                errorMessage={t(extractValidationKey(errors?.country))}
                 defaultValue={loaderData.defaultFormValues?.country ?? ''}
                 required
                 options={countryOptions}
@@ -168,13 +168,13 @@ export default function BirthDetails({ actionData, loaderData, matches, params }
                       label={t('protected:birth-details.province.label')}
                       name="province"
                       options={provinceTerritoryStateOptions}
-                      errorMessage={t(getSingleKey(errors?.province))}
+                      errorMessage={t(extractValidationKey(errors?.province))}
                       defaultValue={loaderData.defaultFormValues?.province}
                       required
                     />
                   ) : (
                     <InputField
-                      errorMessage={t(getSingleKey(errors?.province))}
+                      errorMessage={t(extractValidationKey(errors?.province))}
                       label={t('protected:birth-details.province.label')}
                       name="province"
                       defaultValue={loaderData.defaultFormValues?.province}
@@ -184,7 +184,7 @@ export default function BirthDetails({ actionData, loaderData, matches, params }
                     />
                   )}
                   <InputField
-                    errorMessage={t(getSingleKey(errors?.city))}
+                    errorMessage={t(extractValidationKey(errors?.city))}
                     label={t('protected:birth-details.city.label')}
                     name="city"
                     defaultValue={loaderData.defaultFormValues?.city}
@@ -198,7 +198,7 @@ export default function BirthDetails({ actionData, loaderData, matches, params }
                     name="from-multiple"
                     options={fromMultipleBirthOptions}
                     required
-                    errorMessage={t(getSingleKey(errors?.fromMultipleBirth))}
+                    errorMessage={t(extractValidationKey(errors?.fromMultipleBirth))}
                   />
                 </>
               )}

--- a/frontend/app/routes/protected/person-case/contact-information.tsx
+++ b/frontend/app/routes/protected/person-case/contact-information.tsx
@@ -27,7 +27,7 @@ import { handle as parentHandle } from '~/routes/protected/person-case/layout';
 import { getTabIdOrRedirect, loadMachineActorOrRedirect } from '~/routes/protected/person-case/route-helpers.server';
 import { getStateRoute } from '~/routes/protected/person-case/state-machine.server';
 import { contactInformationSchema } from '~/routes/protected/person-case/validation.server';
-import { getSingleKey } from '~/utils/i18n-utils';
+import { extractValidationKey } from '~/utils/validation-utils';
 
 export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace, 'protected'],
@@ -148,7 +148,7 @@ export default function ContactInformation({ loaderData, actionData, params }: R
                 legend={t('protected:contact-information.preferred-language-label')}
                 name="preferredLanguage"
                 options={languageOptions}
-                errorMessage={t(getSingleKey(errors?.preferredLanguage))}
+                errorMessage={t(extractValidationKey(errors?.preferredLanguage))}
                 required
               />
               <InputPhoneField
@@ -157,7 +157,7 @@ export default function ContactInformation({ loaderData, actionData, params }: R
                 name="primaryPhoneNumber"
                 type="tel"
                 inputMode="tel"
-                errorMessage={t(getSingleKey(errors?.primaryPhoneNumber))}
+                errorMessage={t(extractValidationKey(errors?.primaryPhoneNumber))}
                 defaultValue={loaderData.defaultFormValues?.primaryPhoneNumber}
                 required
               />
@@ -167,7 +167,7 @@ export default function ContactInformation({ loaderData, actionData, params }: R
                 name="secondaryPhoneNumber"
                 type="tel"
                 inputMode="tel"
-                errorMessage={t(getSingleKey(errors?.secondaryPhoneNumber))}
+                errorMessage={t(extractValidationKey(errors?.secondaryPhoneNumber))}
                 defaultValue={loaderData.defaultFormValues?.secondaryPhoneNumber}
               />
               <div className="max-w-prose">
@@ -178,7 +178,7 @@ export default function ContactInformation({ loaderData, actionData, params }: R
                   label={t('protected:contact-information.email-label')}
                   name="emailAddress"
                   className="w-full"
-                  errorMessage={t(getSingleKey(errors?.emailAddress))}
+                  errorMessage={t(extractValidationKey(errors?.emailAddress))}
                   defaultValue={loaderData.defaultFormValues?.emailAddress}
                 />
               </div>
@@ -189,7 +189,7 @@ export default function ContactInformation({ loaderData, actionData, params }: R
                 name="country"
                 label={t('protected:contact-information.country-select-label')}
                 options={countryOptions}
-                errorMessage={t(getSingleKey(errors?.country))}
+                errorMessage={t(extractValidationKey(errors?.country))}
                 value={country}
                 onChange={({ target }) => setCountry(target.value)}
                 required
@@ -202,7 +202,7 @@ export default function ContactInformation({ loaderData, actionData, params }: R
                     helpMessagePrimary={t('protected:contact-information.address-help-message')}
                     name="address"
                     className="w-full"
-                    errorMessage={t(getSingleKey(errors?.address))}
+                    errorMessage={t(extractValidationKey(errors?.address))}
                     defaultValue={loaderData.defaultFormValues?.address}
                     required
                   />
@@ -211,7 +211,7 @@ export default function ContactInformation({ loaderData, actionData, params }: R
                     label={t('protected:contact-information.city-label')}
                     name="city"
                     className="w-full"
-                    errorMessage={t(getSingleKey(errors?.city))}
+                    errorMessage={t(extractValidationKey(errors?.city))}
                     defaultValue={loaderData.defaultFormValues?.city}
                     required
                   />
@@ -222,7 +222,7 @@ export default function ContactInformation({ loaderData, actionData, params }: R
                       label={t('protected:contact-information.canada-province-label')}
                       name="province"
                       options={provinceTerritoryStateOptions}
-                      errorMessage={t(getSingleKey(errors?.province))}
+                      errorMessage={t(extractValidationKey(errors?.province))}
                       defaultValue={loaderData.defaultFormValues?.province}
                       required
                     />
@@ -232,7 +232,7 @@ export default function ContactInformation({ loaderData, actionData, params }: R
                       label={t('protected:contact-information.other-country-province-label')}
                       name="province"
                       className="w-full"
-                      errorMessage={t(getSingleKey(errors?.province))}
+                      errorMessage={t(extractValidationKey(errors?.province))}
                       defaultValue={loaderData.defaultFormValues?.province}
                       required
                     />
@@ -241,7 +241,7 @@ export default function ContactInformation({ loaderData, actionData, params }: R
                     id="postal-code"
                     label={t('protected:contact-information.postal-code-label')}
                     name="postalCode"
-                    errorMessage={t(getSingleKey(errors?.postalCode))}
+                    errorMessage={t(extractValidationKey(errors?.postalCode))}
                     defaultValue={loaderData.defaultFormValues?.postalCode}
                     required
                     className="w-full sm:w-1/2"

--- a/frontend/app/routes/protected/person-case/current-name.tsx
+++ b/frontend/app/routes/protected/person-case/current-name.tsx
@@ -26,8 +26,8 @@ import { getTabIdOrRedirect, loadMachineActorOrRedirect } from '~/routes/protect
 import type { CurrentNameData } from '~/routes/protected/person-case/state-machine-models';
 import { getStateRoute } from '~/routes/protected/person-case/state-machine.server';
 import { currentNameSchema } from '~/routes/protected/person-case/validation.server';
-import { getSingleKey } from '~/utils/i18n-utils';
 import { trimToUndefined } from '~/utils/string-utils';
+import { extractValidationKey } from '~/utils/validation-utils';
 
 const REQUIRE_OPTIONS = {
   yes: 'Yes', //
@@ -199,7 +199,7 @@ export default function CurrentName({ loaderData, actionData, params }: Route.Co
           <fetcher.Form method="post" noValidate>
             <div className="space-y-6">
               <InputRadios
-                errorMessage={t(getSingleKey(formErrors?.preferredSameAsDocumentName))}
+                errorMessage={t(extractValidationKey(formErrors?.preferredSameAsDocumentName))}
                 id="same-name-id"
                 legend={t('protected:current-name.preferred-name.description')}
                 name="same-name"
@@ -209,7 +209,7 @@ export default function CurrentName({ loaderData, actionData, params }: Route.Co
               {sameName === false && (
                 <>
                   <InputField
-                    errorMessage={t(getSingleKey(formErrors?.firstName), { maximum: 100 })}
+                    errorMessage={t(extractValidationKey(formErrors?.firstName), { maximum: 100 })}
                     label={t('protected:current-name.preferred-name.first-name')}
                     name="first-name"
                     defaultValue={formValues?.firstName}
@@ -217,14 +217,14 @@ export default function CurrentName({ loaderData, actionData, params }: Route.Co
                     className="w-full"
                   />
                   <InputField
-                    errorMessage={t(getSingleKey(formErrors?.middleName), { maximum: 100 })}
+                    errorMessage={t(extractValidationKey(formErrors?.middleName), { maximum: 100 })}
                     label={t('protected:current-name.preferred-name.middle-name')}
                     name="middle-name"
                     defaultValue={formValues?.middleName}
                     className="w-full"
                   />
                   <InputField
-                    errorMessage={t(getSingleKey(formErrors?.lastName), { maximum: 100 })}
+                    errorMessage={t(extractValidationKey(formErrors?.lastName), { maximum: 100 })}
                     label={t('protected:current-name.preferred-name.last-name')}
                     name="last-name"
                     defaultValue={formValues?.lastName}
@@ -238,7 +238,7 @@ export default function CurrentName({ loaderData, actionData, params }: Route.Co
                     <p>{t('protected:current-name.supporting-docs.description')}</p>
                     <InputRadios
                       id="docs-required-id"
-                      errorMessage={t(getSingleKey(formErrors?.['supportingDocuments.required']))}
+                      errorMessage={t(extractValidationKey(formErrors?.['supportingDocuments.required']))}
                       legend={t('protected:current-name.supporting-docs.docs-required')}
                       name="docs-required"
                       options={requireOptions}
@@ -247,7 +247,7 @@ export default function CurrentName({ loaderData, actionData, params }: Route.Co
                     {requireDoc === true && (
                       <InputCheckboxes
                         id="doc-type-id"
-                        errorMessage={t(getSingleKey(formErrors?.['supportingDocuments.documentTypes']))}
+                        errorMessage={t(extractValidationKey(formErrors?.['supportingDocuments.documentTypes']))}
                         legend={t('protected:current-name.supporting-docs.doc-type')}
                         name="doc-type"
                         options={docTypes}

--- a/frontend/app/routes/protected/person-case/parent-details.tsx
+++ b/frontend/app/routes/protected/person-case/parent-details.tsx
@@ -26,8 +26,8 @@ import { handle as parentHandle } from '~/routes/protected/person-case/layout';
 import { getTabIdOrRedirect, loadMachineActorOrRedirect } from '~/routes/protected/person-case/route-helpers.server';
 import { getStateRoute } from '~/routes/protected/person-case/state-machine.server';
 import { maxNumberOfParents, parentDetailsSchema } from '~/routes/protected/person-case/validation.server';
-import { getSingleKey } from '~/utils/i18n-utils';
 import { trimToUndefined } from '~/utils/string-utils';
+import { extractValidationKey } from '~/utils/validation-utils';
 
 export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace, 'protected'],
@@ -222,7 +222,7 @@ function ParentForm({ index, loaderData, errors, onRemove }: ParentFormProps) {
         )}
       </div>
       <InputCheckbox
-        errorMessage={t(getSingleKey(errors?.[`${index}.unavailable`]))}
+        errorMessage={t(extractValidationKey(errors?.[`${index}.unavailable`]))}
         id={`${index}-unavailable-id`}
         name={`${index}-unavailable`}
         defaultChecked={unavailable ?? false}
@@ -234,7 +234,7 @@ function ParentForm({ index, loaderData, errors, onRemove }: ParentFormProps) {
       {!unavailable && (
         <>
           <InputField
-            errorMessage={t(getSingleKey(errors?.[`${index}.givenName`]))}
+            errorMessage={t(extractValidationKey(errors?.[`${index}.givenName`]))}
             label={t('protected:parent-details.given-name')}
             name={`${index}-given-name`}
             defaultValue={defaultValues?.givenName ?? ''}
@@ -243,7 +243,7 @@ function ParentForm({ index, loaderData, errors, onRemove }: ParentFormProps) {
             className="w-full"
           />
           <InputField
-            errorMessage={t(getSingleKey(errors?.[`${index}.lastName`]))}
+            errorMessage={t(extractValidationKey(errors?.[`${index}.lastName`]))}
             label={t('protected:parent-details.last-name')}
             name={`${index}-last-name`}
             defaultValue={defaultValues?.lastName ?? ''}
@@ -252,7 +252,7 @@ function ParentForm({ index, loaderData, errors, onRemove }: ParentFormProps) {
             className="w-full"
           />
           <InputSelect
-            errorMessage={t(getSingleKey(errors?.[`${index}.birthLocation.country`]))}
+            errorMessage={t(extractValidationKey(errors?.[`${index}.birthLocation.country`]))}
             className="w-full sm:w-1/2"
             id={`${index}-country-id`}
             name={`${index}-country`}
@@ -263,7 +263,7 @@ function ParentForm({ index, loaderData, errors, onRemove }: ParentFormProps) {
           />
           {country === globalThis.__appEnvironment.PP_CANADA_COUNTRY_CODE ? (
             <InputSelect
-              errorMessage={t(getSingleKey(errors?.[`${index}.birthLocation.province`]))}
+              errorMessage={t(extractValidationKey(errors?.[`${index}.birthLocation.province`]))}
               className="w-full sm:w-1/2"
               id={`${index}-province-id`}
               name={`${index}-province`}
@@ -273,7 +273,7 @@ function ParentForm({ index, loaderData, errors, onRemove }: ParentFormProps) {
             />
           ) : (
             <InputField
-              errorMessage={t(getSingleKey(errors?.[`${index}.birthLocation.province`]))}
+              errorMessage={t(extractValidationKey(errors?.[`${index}.birthLocation.province`]))}
               className="w-full"
               label={t('protected:parent-details.province')}
               name={`${index}-province`}
@@ -282,7 +282,7 @@ function ParentForm({ index, loaderData, errors, onRemove }: ParentFormProps) {
             />
           )}
           <InputField
-            errorMessage={t(getSingleKey(errors?.[`${index}.birthLocation.city`]))}
+            errorMessage={t(extractValidationKey(errors?.[`${index}.birthLocation.city`]))}
             className="w-full"
             label={t('protected:parent-details.city')}
             name={`${index}-city`}

--- a/frontend/app/routes/protected/person-case/personal-info.tsx
+++ b/frontend/app/routes/protected/person-case/personal-info.tsx
@@ -26,8 +26,8 @@ import { handle as parentHandle } from '~/routes/protected/person-case/layout';
 import { getTabIdOrRedirect, loadMachineActorOrRedirect } from '~/routes/protected/person-case/route-helpers.server';
 import { getStateRoute } from '~/routes/protected/person-case/state-machine.server';
 import { personalInfoSchema } from '~/routes/protected/person-case/validation.server';
-import { getSingleKey } from '~/utils/i18n-utils';
 import { REGEX_PATTERNS } from '~/utils/regex-utils';
+import { extractValidationKey } from '~/utils/validation-utils';
 
 export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace, 'protected'],
@@ -280,7 +280,7 @@ export default function PersonalInformation({ actionData, loaderData, params, ma
               <InputField
                 id="last-name-at-birth-id"
                 defaultValue={loaderData.defaultFormValues.lastNameAtBirth ?? loaderData.primaryDocValues.lastName}
-                errorMessage={t(getSingleKey(errors?.lastNameAtBirth), { maximum: 100 })}
+                errorMessage={t(extractValidationKey(errors?.lastNameAtBirth), { maximum: 100 })}
                 label={t('protected:personal-information.last-name-at-birth.label')}
                 name="lastNameAtBirth"
                 required
@@ -338,7 +338,7 @@ export default function PersonalInformation({ actionData, loaderData, params, ma
 
               <InputRadios
                 id="gender-id"
-                errorMessage={t(getSingleKey(errors?.gender))}
+                errorMessage={t(extractValidationKey(errors?.gender))}
                 helpMessagePrimary={t('protected:personal-information.gender.help-message-primary')}
                 legend={t('protected:personal-information.gender.label')}
                 name="gender"

--- a/frontend/app/routes/protected/person-case/previous-sin.tsx
+++ b/frontend/app/routes/protected/person-case/previous-sin.tsx
@@ -25,8 +25,8 @@ import { handle as parentHandle } from '~/routes/protected/person-case/layout';
 import { getTabIdOrRedirect, loadMachineActorOrRedirect } from '~/routes/protected/person-case/route-helpers.server';
 import { getStateRoute } from '~/routes/protected/person-case/state-machine.server';
 import { previousSinSchema } from '~/routes/protected/person-case/validation.server';
-import { getSingleKey } from '~/utils/i18n-utils';
 import { sinInputPatternFormat } from '~/utils/sin-utils';
+import { extractValidationKey } from '~/utils/validation-utils';
 
 export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace, 'protected'],
@@ -126,7 +126,7 @@ export default function PreviousSin({ loaderData, actionData, params }: Route.Co
                 name="hasPreviousSin"
                 options={hasPreviousSinOptions}
                 required
-                errorMessage={t(getSingleKey(errors?.hasPreviousSin))}
+                errorMessage={t(extractValidationKey(errors?.hasPreviousSin))}
               />
               {hasPreviousSin === globalThis.__appEnvironment.PP_HAS_HAD_PREVIOUS_SIN_CODE && (
                 <InputPatternField
@@ -136,7 +136,7 @@ export default function PreviousSin({ loaderData, actionData, params }: Route.Co
                   id="social-insurance-number"
                   name="socialInsuranceNumber"
                   label={t('protected:previous-sin.social-insurance-number-label')}
-                  errorMessage={t(getSingleKey(errors?.socialInsuranceNumber))}
+                  errorMessage={t(extractValidationKey(errors?.socialInsuranceNumber))}
                   required
                 />
               )}

--- a/frontend/app/routes/protected/person-case/privacy-statement.tsx
+++ b/frontend/app/routes/protected/person-case/privacy-statement.tsx
@@ -22,7 +22,7 @@ import { handle as parentHandle } from '~/routes/protected/person-case/layout';
 import { getTabIdOrRedirect, loadMachineActorOrRedirect } from '~/routes/protected/person-case/route-helpers.server';
 import { createMachineActor, getStateRoute } from '~/routes/protected/person-case/state-machine.server';
 import { privacyStatementSchema } from '~/routes/protected/person-case/validation.server';
-import { getSingleKey } from '~/utils/i18n-utils';
+import { extractValidationKey } from '~/utils/validation-utils';
 
 export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace, 'protected'],
@@ -112,7 +112,7 @@ export default function PrivacyStatement({ loaderData, params }: Route.Component
               <InputCheckbox
                 id="agreed-to-terms"
                 name="agreedToTerms"
-                errorMessage={t(getSingleKey(errors?.agreedToTerms))}
+                errorMessage={t(extractValidationKey(errors?.agreedToTerms))}
                 required
               >
                 {t('protected:privacy-statement.confirm-privacy-notice-checkbox.title')}

--- a/frontend/app/routes/protected/person-case/request-details.tsx
+++ b/frontend/app/routes/protected/person-case/request-details.tsx
@@ -24,7 +24,7 @@ import { handle as parentHandle } from '~/routes/protected/person-case/layout';
 import { getTabIdOrRedirect, loadMachineActorOrRedirect } from '~/routes/protected/person-case/route-helpers.server';
 import { getStateRoute } from '~/routes/protected/person-case/state-machine.server';
 import { requestDetailsSchema } from '~/routes/protected/person-case/validation.server';
-import { getSingleKey } from '~/utils/i18n-utils';
+import { extractValidationKey } from '~/utils/validation-utils';
 
 export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace, 'protected'],
@@ -145,7 +145,7 @@ export default function RequestDetails({ actionData, loaderData, params }: Route
                 name="scenario"
                 options={scenarioOptions}
                 required
-                errorMessage={t(getSingleKey(formErrors?.scenario))}
+                errorMessage={t(extractValidationKey(formErrors?.scenario))}
               />
               <InputSelect
                 className="w-full"
@@ -154,7 +154,7 @@ export default function RequestDetails({ actionData, loaderData, params }: Route
                 label={t('protected:request-details.type-request')}
                 defaultValue={formValues?.type ?? ''}
                 options={requestOptions}
-                errorMessage={t(getSingleKey(formErrors?.type))}
+                errorMessage={t(extractValidationKey(formErrors?.type))}
                 required
               />
             </div>

--- a/frontend/app/routes/protected/person-case/secondary-doc.tsx
+++ b/frontend/app/routes/protected/person-case/secondary-doc.tsx
@@ -24,7 +24,7 @@ import { handle as parentHandle } from '~/routes/protected/person-case/layout';
 import { getTabIdOrRedirect, loadMachineActorOrRedirect } from '~/routes/protected/person-case/route-helpers.server';
 import { getStateRoute } from '~/routes/protected/person-case/state-machine.server';
 import { secondaryDocumentSchema } from '~/routes/protected/person-case/validation.server';
-import { getSingleKey } from '~/utils/i18n-utils';
+import { extractValidationKey } from '~/utils/validation-utils';
 
 export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace, 'protected'],
@@ -132,7 +132,7 @@ export default function SecondaryDoc({ actionData, loaderData, params }: Route.C
                 name="document-type"
                 options={docOptions}
                 required
-                errorMessage={t(getSingleKey(formErrors?.documentType))}
+                errorMessage={t(extractValidationKey(formErrors?.documentType))}
               />
               <DatePickerField
                 defaultValue={{
@@ -147,8 +147,8 @@ export default function SecondaryDoc({ actionData, loaderData, params }: Route.C
                   year: 'expiry-year',
                 }}
                 errorMessages={{
-                  year: t(getSingleKey(formErrors?.expiryYear)),
-                  month: t(getSingleKey(formErrors?.expiryMonth)),
+                  year: t(extractValidationKey(formErrors?.expiryYear)),
+                  month: t(extractValidationKey(formErrors?.expiryMonth)),
                 }}
               />
               <InputFile

--- a/frontend/app/routes/protected/sin-application/primary-docs-form.tsx
+++ b/frontend/app/routes/protected/sin-application/primary-docs-form.tsx
@@ -15,7 +15,7 @@ import { InputRadios } from '~/components/input-radios';
 import { InputSelect } from '~/components/input-select';
 import { APPLICANT_PRIMARY_DOCUMENT_CHOICE, APPLICANT_STATUS_IN_CANADA } from '~/domain/constants';
 import type { Errors, PrimaryDocumentData } from '~/routes/protected/person-case/state-machine-models';
-import { getSingleKey } from '~/utils/i18n-utils';
+import { extractValidationKey } from '~/utils/validation-utils';
 
 interface PrimaryDocsFormProps {
   formValues: Partial<PrimaryDocumentData> | undefined;
@@ -53,14 +53,14 @@ export default function PrimaryDocsForm({
         value={currentStatus}
         onChange={handleOnCurrentStatusInCanadaChanged}
         statusInCanadaChoices={statusInCanadaChoices}
-        errorMessage={t(getSingleKey(formErrors?.currentStatusInCanada))}
+        errorMessage={t(extractValidationKey(formErrors?.currentStatusInCanada))}
       />
       {currentStatus.length > 0 && (
         <DocumentType
           value={documentType}
           onChange={({ target }) => setDocumentType(target.value)}
           documentTypeChoices={documentTypeChoices}
-          error={t(getSingleKey(formErrors?.documentType))}
+          error={t(extractValidationKey(formErrors?.documentType))}
         />
       )}
       {documentType.length > 0 && (
@@ -166,7 +166,7 @@ function PrimaryDocsFields({ documentType, formErrors, formValues, genders }: Pr
           <InputField
             id="registration-number-id"
             defaultValue={formValues?.registrationNumber}
-            errorMessage={t(getSingleKey(formErrors?.registrationNumber), { length: 8 })}
+            errorMessage={t(extractValidationKey(formErrors?.registrationNumber), { length: 8 })}
             label={t('protected:primary-identity-document.registration-number.label')}
             name="registrationNumber"
             required
@@ -175,7 +175,7 @@ function PrimaryDocsFields({ documentType, formErrors, formValues, genders }: Pr
           <InputField
             id="client-number-id"
             defaultValue={formValues?.clientNumber}
-            errorMessage={t(getSingleKey(formErrors?.clientNumber), { length: 10 })}
+            errorMessage={t(extractValidationKey(formErrors?.clientNumber), { length: 10 })}
             label={t('protected:primary-identity-document.client-number.label')}
             name="clientNumber"
             required
@@ -184,7 +184,7 @@ function PrimaryDocsFields({ documentType, formErrors, formValues, genders }: Pr
           <InputField
             id="given-name-id"
             defaultValue={formValues?.givenName}
-            errorMessage={t(getSingleKey(formErrors?.givenName), { maximum: 100 })}
+            errorMessage={t(extractValidationKey(formErrors?.givenName), { maximum: 100 })}
             helpMessagePrimary={t('protected:primary-identity-document.given-name.help-message-primary')}
             label={t('protected:primary-identity-document.given-name.label')}
             name="givenName"
@@ -195,7 +195,7 @@ function PrimaryDocsFields({ documentType, formErrors, formValues, genders }: Pr
           <InputField
             id="last-name-id"
             defaultValue={formValues?.lastName}
-            errorMessage={t(getSingleKey(formErrors?.lastName), { maximum: 100 })}
+            errorMessage={t(extractValidationKey(formErrors?.lastName), { maximum: 100 })}
             helpMessagePrimary={t('protected:primary-identity-document.last-name.help-message-primary')}
             label={t('protected:primary-identity-document.last-name.label')}
             name="lastName"
@@ -210,15 +210,15 @@ function PrimaryDocsFields({ documentType, formErrors, formValues, genders }: Pr
             required
             names={{ day: 'dateOfBirthDay', month: 'dateOfBirthMonth', year: 'dateOfBirthYear' }}
             errorMessages={{
-              all: t(getSingleKey(formErrors?.dateOfBirth)),
-              year: t(getSingleKey(formErrors?.dateOfBirthYear)),
-              month: t(getSingleKey(formErrors?.dateOfBirthMonth)),
-              day: t(getSingleKey(formErrors?.dateOfBirthDay)),
+              all: t(extractValidationKey(formErrors?.dateOfBirth)),
+              year: t(extractValidationKey(formErrors?.dateOfBirthYear)),
+              month: t(extractValidationKey(formErrors?.dateOfBirthMonth)),
+              day: t(extractValidationKey(formErrors?.dateOfBirthDay)),
             }}
           />
           <InputRadios
             id="gender-id"
-            errorMessage={t(getSingleKey(formErrors?.gender))}
+            errorMessage={t(extractValidationKey(formErrors?.gender))}
             legend={t('protected:primary-identity-document.gender.label')}
             name="gender"
             options={genderOptions}
@@ -231,10 +231,10 @@ function PrimaryDocsFields({ documentType, formErrors, formValues, genders }: Pr
             required
             names={{ day: 'citizenshipDateDay', month: 'citizenshipDateMonth', year: 'citizenshipDateYear' }}
             errorMessages={{
-              all: t(getSingleKey(formErrors?.citizenshipDate)),
-              year: t(getSingleKey(formErrors?.citizenshipDateYear)),
-              month: t(getSingleKey(formErrors?.citizenshipDateMonth)),
-              day: t(getSingleKey(formErrors?.citizenshipDateDay)),
+              all: t(extractValidationKey(formErrors?.citizenshipDate)),
+              year: t(extractValidationKey(formErrors?.citizenshipDateYear)),
+              month: t(extractValidationKey(formErrors?.citizenshipDateMonth)),
+              day: t(extractValidationKey(formErrors?.citizenshipDateDay)),
             }}
           />
           <InputFile

--- a/frontend/app/utils/i18n-utils.ts
+++ b/frontend/app/utils/i18n-utils.ts
@@ -1,6 +1,6 @@
 import type { RouteModule } from 'react-router';
 
-import type { Namespace, ResourceKey } from 'i18next';
+import type { Namespace } from 'i18next';
 
 /**
  * Returns the i81n namespace required by the given routes by examining the route's i18nNamespace handle property.
@@ -67,22 +67,4 @@ function getLanguageFromPath(pathname: string): Language | undefined {
       return undefined;
     }
   }
-}
-
-/**
- * Retrieves a `ResourceKey` from a given value, handling both single values and arrays.
- *
- * This function serves two purposes:
- *
- * 1. **Extracting a `ResourceKey`** – If given an array, it selects an element at the specified index.
- * 2. **Ensuring type compatibility with `i18next`** – Valibot returns plain strings when validation fails,
- *    which does not match the expected `ResourceKey` type in i18next. By returning a `ResourceKey`,
- *    this function effectively casts the input as a valid `ResourceKey`, preventing TypeScript errors.
- *
- * @param value - A single `ResourceKey` or an array of `ResourceKey` values.
- * @param index - The index to select from the array (defaults to the first element).
- * @returns A `ResourceKey` from the input or `undefined` if the value is not provided.
- */
-export function getSingleKey<T extends ResourceKey>(value: T | [T, ...T[]] | undefined, index = 0): ResourceKey | undefined {
-  return Array.isArray(value) ? value.at(index) : value;
 }

--- a/frontend/app/utils/validation-utils.ts
+++ b/frontend/app/utils/validation-utils.ts
@@ -1,3 +1,28 @@
+import type { ResourceKey } from 'i18next';
+
+/**
+ * Normalizes validation error messages into a single i18next `ResourceKey`.
+ *
+ * Valibot validation errors are typically arrays of strings, but i18next
+ * expects a single `ResourceKey`. This function extracts a key from the array
+ * and effectively casts it as a `ResourceKey`, allowing the result to be safely
+ * used with i18next while maintaining TypeScript compatibility.
+ *
+ * - If `value` is a single `ResourceKey` (ie: `string`), it is returned unchanged.
+ * - If `value` is an array, the element at `index` (defaulting to `0`) is returned.
+ * - If `value` is `undefined`, the function returns `undefined`.
+ *
+ * @param value - A `ResourceKey` (ie: `string`) or an array of `ResourceKey` values (typically from Valibot).
+ * @param index - The position of the key to extract from an array (defaults to the first element).
+ * @returns A single `ResourceKey` or `undefined` if no valid value is provided.
+ */
+export function extractValidationKey<T extends ResourceKey>(
+  value: T | [T, ...T[]] | undefined,
+  index?: number,
+): ResourceKey | undefined {
+  return Array.isArray(value) ? value.at(index ?? 0) : value;
+}
+
 /**
  * Preprocesses validation input.
  *

--- a/frontend/tests/utils/i18n-utils.test.ts
+++ b/frontend/tests/utils/i18n-utils.test.ts
@@ -2,7 +2,7 @@ import type { RouteModule } from 'react-router';
 
 import { describe, expect, it } from 'vitest';
 
-import { getAltLanguage, getI18nNamespace, getLanguage, getSingleKey } from '~/utils/i18n-utils';
+import { getAltLanguage, getI18nNamespace, getLanguage } from '~/utils/i18n-utils';
 
 describe('i18n-utils', () => {
   describe('getI18nNamespace', () => {
@@ -66,30 +66,6 @@ describe('i18n-utils', () => {
       expect(getAltLanguage('en')).toEqual('fr');
       expect(getAltLanguage('fr')).toEqual('en');
       expect(getAltLanguage('es')).toBeUndefined();
-    });
-  });
-
-  describe('getSingleKey', () => {
-    it('should return the single key if a single key is provided', () => {
-      expect(getSingleKey('key')).toBe('key');
-    });
-
-    it('should return the first key if an array of keys is provided', () => {
-      expect(getSingleKey(['key1', 'key2'])).toBe('key1');
-    });
-
-    it('should return the key at the specified index if an array of keys and an index are provided', () => {
-      expect(getSingleKey(['key1', 'key2', 'key3'], 1)).toBe('key2');
-      expect(getSingleKey(['key1', 'key2', 'key3'], 2)).toBe('key3');
-    });
-
-    it('should return undefined if no value is provided', () => {
-      expect(getSingleKey(undefined)).toBeUndefined();
-    });
-
-    it('should return undefined if index is out of bounds', () => {
-      expect(getSingleKey(['key1', 'key2'], 5)).toBeUndefined();
-      expect(getSingleKey(['key1', 'key2'], -1)).toBe('key2');
     });
   });
 });

--- a/frontend/tests/utils/validation-utils.test.ts
+++ b/frontend/tests/utils/validation-utils.test.ts
@@ -1,20 +1,44 @@
 import { describe, expect, it } from 'vitest';
 
-import * as validationUtils from '~/utils/validation-utils';
+import { extractValidationKey, preprocess } from '~/utils/validation-utils';
 
 describe('validationUtils', () => {
+  describe('extractValidationKey', () => {
+    it('should return the single key if a single key is provided', () => {
+      expect(extractValidationKey('key')).toBe('key');
+    });
+
+    it('should return the first key if an array of keys is provided', () => {
+      expect(extractValidationKey(['key1', 'key2'])).toBe('key1');
+    });
+
+    it('should return the key at the specified index if an array of keys and an index are provided', () => {
+      expect(extractValidationKey(['key1', 'key2', 'key3'], 1)).toBe('key2');
+      expect(extractValidationKey(['key1', 'key2', 'key3'], 2)).toBe('key3');
+    });
+
+    it('should return undefined if no value is provided', () => {
+      expect(extractValidationKey(undefined)).toBeUndefined();
+    });
+
+    it('should return undefined if index is out of bounds', () => {
+      expect(extractValidationKey(['key1', 'key2'], 5)).toBeUndefined();
+      expect(extractValidationKey(['key1', 'key2'], -1)).toBe('key2');
+    });
+  });
+
   describe('preprocess', () => {
     it('should replace empty strings with undefined', () => {
       const input = { a: '', b: 'b', c: 123 };
       const expected = { a: undefined, b: 'b', c: 123 };
-      const result = validationUtils.preprocess(input);
+      const result = preprocess(input);
       expect(result).toEqual(expected);
     });
 
     it('should handle empty input', () => {
       const input = {};
       const expected = {};
-      const result = validationUtils.preprocess(input);
+      const result = preprocess(input);
       expect(result).toEqual(expected);
     });
   });


### PR DESCRIPTION
## Summary

Refactor how the valibot i18n keys are handled:

- move `getSingleKey()` to `validation-utils`
- rename `getSingleKey()` to `extractValidationKey()`
- rewrite jsdoc to better explain the purpose of this function:
  ```ts
  /**
   * Normalizes validation error messages into a single i18next `ResourceKey`.
   *
   * Valibot validation errors are typically arrays of strings, but i18next
   * expects a single `ResourceKey`. This function extracts a key from the array
   * and effectively casts it as a `ResourceKey`, allowing the result to be safely
   * used with i18next while maintaining TypeScript compatibility.
   *
   * - If `value` is a single `ResourceKey` (ie: `string`), it is returned unchanged.
   * - If `value` is an array, the element at `index` (defaulting to `0`) is returned.
   * - If `value` is `undefined`, the function returns `undefined`.
   */
  export function extractValidationKey<T extends ResourceKey>(..);
  ```
- update tests

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)
