### PR TITLE
chore(frontend): add missing envar to `.env.example`

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -42,10 +42,16 @@ ENABLE_SIN_APPLICATION_SERVICE_MOCK=
 # for local development on localhost when testing with production-like settings.
 ENABLE_SIN_CASE_SERVICE_MOCK=
 
+# Enable the mock SIN search service for development purposes (default: false in production)
+# Note: Although the default is false in production mode, you can override it to true
+# for local development on localhost when testing with production-like settings.
+ENABLE_SIN_SEARCH_SERVICE_MOCK=
+
 # Enable the mock SIN association service for development purposes (default: false in production)
 # Note: Although the default is false in production mode, you can override it to true
 # for local development on localhost when testing with production-like settings.
 ENABLE_ASSOCIATE_SIN_SERVICE_MOCK=
+
 
 
 #################################################
@@ -230,6 +236,8 @@ PP_SIN_CONFIRMATION_RECEIVING_METHOD_BY_MAIL_CODE=
 PP_LANGUAGE_OF_CORRESPONDENCE_ENGLISH_CODE=
 # (default: 564190001)
 PP_LANGUAGE_OF_CORRESPONDENCE_FRENCH_CODE=
+
+
 
 #################################################
 # Interop API configuration


### PR DESCRIPTION
## Summary

The `.env.example` file was missing `ENABLE_SIN_SEARCH_SERVICE_MOCK`.
