### PR TITLE
feat(frontend): Add table reusable components

### DIFF
--- a/frontend/app/components/data-table.tsx
+++ b/frontend/app/components/data-table.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from 'react';
 
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '~/components/table';
+
 type Row = (string | number | ReactNode)[];
 
 interface DataTableProps {
@@ -22,29 +24,27 @@ interface DataTableProps {
 
 export function DataTable({ headers, rows, striped = true }: DataTableProps) {
   return (
-    <div className="overflow-x-auto rounded-lg shadow">
-      <table className="min-w-full divide-y divide-gray-200">
-        <thead className="bg-slate-600">
-          <tr>
-            {headers.map((header, index) => (
-              <th key={index} scope="col" className="px-6 py-3 text-left text-xs font-medium tracking-wider text-white">
-                {header}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-gray-200 bg-white">
-          {rows.map((row, rowIndex) => (
-            <tr key={rowIndex} className={striped && rowIndex % 2 === 1 ? 'bg-gray-50' : 'bg-white'}>
-              {row.map((cell, cellIndex) => (
-                <td key={cellIndex} className="px-6 py-4 text-sm whitespace-nowrap text-gray-900">
-                  {cell}
-                </td>
-              ))}
-            </tr>
+    <Table>
+      <TableHeader>
+        <TableRow>
+          {headers.map((header, index) => (
+            <TableHead key={index} scope="col">
+              {header}
+            </TableHead>
           ))}
-        </tbody>
-      </table>
-    </div>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rows.map((row, rowIndex) => (
+          <TableRow key={rowIndex}>
+            {row.map((cell, cellIndex) => (
+              <TableCell className="text-nowrap" key={cellIndex}>
+                {cell}
+              </TableCell>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
   );
 }

--- a/frontend/app/components/table.tsx
+++ b/frontend/app/components/table.tsx
@@ -1,0 +1,62 @@
+import type { ComponentProps, JSX } from 'react';
+
+import { cn } from '~/utils/tailwind-utils';
+
+export function Table({ className, ref, ...props }: ComponentProps<'table'>): JSX.Element {
+  return (
+    <div className="relative w-full overflow-x-auto">
+      <table ref={ref} className={cn('w-full caption-bottom text-left text-sm', className)} {...props} />
+    </div>
+  );
+}
+
+export function TableHeader({ className, ref, ...props }: ComponentProps<'thead'>): JSX.Element {
+  return <thead ref={ref} className={cn('[&_tr]:border-b-2', className)} {...props} />;
+}
+
+export function TableBody({ className, ref, ...props }: ComponentProps<'tbody'>): JSX.Element {
+  return <tbody ref={ref} className={cn('[&_tr:last-child]:border-0', className)} {...props} />;
+}
+
+export function TableFooter({ className, ref, ...props }: ComponentProps<'tfoot'>): JSX.Element {
+  return (
+    <tfoot ref={ref} className={cn('border-t bg-neutral-100/50 font-medium [&>tr]:last:border-b-0', className)} {...props} />
+  );
+}
+
+export function TableRow({ className, ref, ...props }: ComponentProps<'tr'>): JSX.Element {
+  return (
+    <tr
+      ref={ref}
+      className={cn('border-b transition-colors hover:bg-neutral-100/50 data-[state=selected]:bg-neutral-100', className)}
+      {...props}
+    />
+  );
+}
+
+export function TableHead({ className, ref, ...props }: ComponentProps<'th'>): JSX.Element {
+  return (
+    <th
+      ref={ref}
+      className={cn(
+        'h-10 p-3 text-left align-middle font-medium [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function TableCell({ className, ref, ...props }: ComponentProps<'td'>): JSX.Element {
+  return (
+    <td
+      ref={ref}
+      className={cn('px-3 py-4 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]', className)}
+      {...props}
+    />
+  );
+}
+
+export function TableCaption({ className, ref, ...props }: ComponentProps<'caption'>): JSX.Element {
+  return <caption ref={ref} className={cn('mt-4 text-sm text-current/80', className)} {...props} />;
+}


### PR DESCRIPTION
## Summary

Add table reusable components based of [Shadcn Table](https://ui.shadcn.com/docs/components/table) and [Flowbite Table](https://flowbite.com/docs/components/tables/) style. Unit tests will follow in another PR.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

![localhost_3000_en_protected_cases_f5b8f5aa-2286-4f5b-bab2-6171868a732c_multi-channel_search-sin](https://github.com/user-attachments/assets/0828b5a1-387b-41ca-b74c-7db3f8ad5e31)
