### PR TITLE
feat(frontend) make applicant tombstone data uppercase in /sin-confir…

### DIFF
--- a/frontend/app/routes/protected/multi-channel/sin-confirmation.tsx
+++ b/frontend/app/routes/protected/multi-channel/sin-confirmation.tsx
@@ -23,6 +23,7 @@ import { HttpStatusCodes } from '~/errors/http-status-codes';
 import { getTranslation } from '~/i18n-config.server';
 import { handle as parentHandle } from '~/routes/protected/layout';
 import { dateToLocalizedText } from '~/utils/date-utils';
+import { cn } from '~/utils/tailwind-utils';
 
 export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace, 'protected'],
@@ -48,8 +49,8 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
       middleNames: [personSinCase.currentNameInfo.middleName],
       familyNames: [
         personSinCase.currentNameInfo.lastName,
-        personSinCase.personalInformation.lastNamePreviouslyUsed,
         personSinCase.primaryDocuments.lastName,
+        ...(personSinCase.personalInformation.lastNamePreviouslyUsed ?? []),
       ].filter((name) => name !== undefined),
       address: personSinCase.contactInformation.address,
       city: personSinCase.contactInformation.city,
@@ -161,24 +162,24 @@ export default function SinConfirmation({ loaderData, actionData, params }: Rout
             <BilingualText resourceKey="protected:sin-confirmation.names-on-record" />
           </h3>
           <dl className="mt-5 grid items-center gap-5">
-            <ConfirmationDetail resourceKey="protected:sin-confirmation.first-name">
+            <ConfirmationDetail upperCase resourceKey="protected:sin-confirmation.first-name">
               {recordDetails.firstName}
             </ConfirmationDetail>
-            <ConfirmationDetail resourceKey="protected:sin-confirmation.middle-name">
+            <ConfirmationDetail upperCase resourceKey="protected:sin-confirmation.middle-name">
               {recordDetails.middleNames.map((name, i) => (
                 <span key={`${name}-${i}`} className="block">
                   {name}
                 </span>
               ))}
             </ConfirmationDetail>
-            <ConfirmationDetail resourceKey="protected:sin-confirmation.family-name">
+            <ConfirmationDetail upperCase resourceKey="protected:sin-confirmation.family-name">
               {recordDetails.familyNames.map((name, i) => (
                 <span key={`${name}-${i}`} className="block">
                   {name}
                 </span>
               ))}
             </ConfirmationDetail>
-            <ConfirmationDetail resourceKey="protected:sin-confirmation.address">
+            <ConfirmationDetail upperCase resourceKey="protected:sin-confirmation.address">
               <span className="block">{recordDetails.address}</span>
               <span className="block">
                 {recordDetails.city && <span className="mr-[0.5ch]">{recordDetails.city}</span>}
@@ -246,16 +247,17 @@ function BilingualText({ resourceKey }: BilingualTextProps) {
 interface ConfirmationDetailProps {
   resourceKey: ResourceKey;
   children: ReactNode;
+  upperCase?: boolean;
 }
 
-function ConfirmationDetail({ resourceKey, children }: ConfirmationDetailProps) {
+function ConfirmationDetail({ resourceKey, children, upperCase = false }: ConfirmationDetailProps) {
   return (
     <div className="grid sm:grid-cols-2 sm:gap-[2.5ch] print:grid-cols-2 print:gap-[2.5ch]">
       <dt className="mt-0 mb-auto flex items-center">
         <BilingualText resourceKey={resourceKey} />:
       </dt>
       <dd className="font-semibold">
-        <span className="block">{children}</span>
+        <span className={cn('block', upperCase && 'uppercase')}>{children}</span>
       </dd>
     </div>
   );


### PR DESCRIPTION
…mation

## Summary

Figma has the applicant's information as uppercase in the sin-confirmation route.  This PR makes it so.

![image](https://github.com/user-attachments/assets/1d5c960d-a777-4a60-9ae8-b5472eeaaf8d)



Provide a concise description of the changes made in this PR. Highlight the purpose, the problem being solved, or the feature being added. If applicable, link to any relevant issue(s).

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
