### PR TITLE
fix(frontend) update sin card names

### DIFF
--- a/frontend/app/routes/protected/multi-channel/search-sin.tsx
+++ b/frontend/app/routes/protected/multi-channel/search-sin.tsx
@@ -48,7 +48,7 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
     firstNamesPreviouslyUsed: personSinCase.personalInformation.firstNamePreviouslyUsed?.join(', '),
     dob: personSinCase.primaryDocuments.dateOfBirth,
     parents: personSinCase.parentDetails.filter((p) => !p.unavailable).map((p) => `${p.givenName} ${p.lastName}`),
-    otherLastNames: personSinCase.personalInformation.lastNamePreviouslyUsed?.join(','),
+    otherLastNames: personSinCase.personalInformation.lastNamePreviouslyUsed?.join(', '),
   };
 }
 

--- a/frontend/app/routes/protected/multi-channel/sin-confirmation.tsx
+++ b/frontend/app/routes/protected/multi-channel/sin-confirmation.tsx
@@ -46,12 +46,8 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
     recordDetails: {
       date: dateToLocalizedText(serverEnvironment.BASE_TIMEZONE),
       firstName: personSinCase.currentNameInfo.firstName ?? personSinCase.primaryDocuments.givenName,
-      middleNames: [personSinCase.currentNameInfo.middleName],
-      familyNames: [
-        personSinCase.currentNameInfo.lastName,
-        personSinCase.primaryDocuments.lastName,
-        ...(personSinCase.personalInformation.lastNamePreviouslyUsed ?? []),
-      ].filter((name) => name !== undefined),
+      middleNames: personSinCase.currentNameInfo.middleName,
+      lastName: personSinCase.currentNameInfo.lastName ?? personSinCase.primaryDocuments.lastName,
       address: personSinCase.contactInformation.address,
       city: personSinCase.contactInformation.city,
       province: personSinCase.contactInformation.province,
@@ -166,18 +162,10 @@ export default function SinConfirmation({ loaderData, actionData, params }: Rout
               {recordDetails.firstName}
             </ConfirmationDetail>
             <ConfirmationDetail upperCase resourceKey="protected:sin-confirmation.middle-name">
-              {recordDetails.middleNames.map((name, i) => (
-                <span key={`${name}-${i}`} className="block">
-                  {name}
-                </span>
-              ))}
+              {recordDetails.middleNames}
             </ConfirmationDetail>
             <ConfirmationDetail upperCase resourceKey="protected:sin-confirmation.family-name">
-              {recordDetails.familyNames.map((name, i) => (
-                <span key={`${name}-${i}`} className="block">
-                  {name}
-                </span>
-              ))}
+              {recordDetails.lastName}
             </ConfirmationDetail>
             <ConfirmationDetail upperCase resourceKey="protected:sin-confirmation.address">
               <span className="block">{recordDetails.address}</span>


### PR DESCRIPTION
## Summary

[AB#19919](https://dev.azure.com/ESDCCM/a4b4f7af-bbd7-4f0d-83ab-a123d0b70fda/_workitems/edit/19919)

Updates the displayed names in the UI based on business requirements.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [ ] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

  ``` shell
  npm run lint:check
  npm run format:check
  ```
</details>

<details>
  <summary>Unit and e2e tests</summary>

  ``` shell
  npm run test
  npm run test:e2e
  ```
</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
