### PR TITLE
fix(frontend): update `Redacted` class to return `undefined` when no initial value is provided

### DIFF
--- a/frontend/app/.server/utils/security-utils.ts
+++ b/frontend/app/.server/utils/security-utils.ts
@@ -35,28 +35,28 @@ export class Redacted<T> {
    * This ensures the value appears redacted when using Node.js debugging tools.
    * @see https://nodejs.org/api/util.html#utilinspectcustom
    *
-   * @returns The value `'<redacted>'`
+   * @returns The value `'<redacted>'` if an initial value was provided, otherwise `undefined`.
    */
-  public [Symbol.for('nodejs.util.inspect.custom')](): '<redacted>' {
+  public [Symbol.for('nodejs.util.inspect.custom')](): '<redacted>' | undefined {
     return this.toString();
   }
 
   /**
    * Controls how the object is serialized when JSON.stringify() is called.
    *
-   * @returns The value `'<redacted>'`
+   * @returns The value `'<redacted>'` if an initial value was provided, otherwise `undefined`.
    */
-  public toJSON(): '<redacted>' {
+  public toJSON(): '<redacted>' | undefined {
     return this.toString();
   }
 
   /**
    * Returns a redacted string representation that hides the actual value.
    *
-   * @returns The value `'<redacted>'`
+   * @returns The value `'<redacted>'` if an initial value was provided, otherwise `undefined`.
    */
-  public toString(): '<redacted>' {
-    return '<redacted>';
+  public toString(): '<redacted>' | undefined {
+    return this.val ? '<redacted>' : undefined;
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR modifies the `Redacted` class to output `undefined` when calling `toString()` to help improve environment variable logging.

## Types of changes

What types of changes does this PR introduce?
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
*(check all that apply by placing an `x` in the relevant boxes)*

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)
